### PR TITLE
Tweak makefile to use test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ gulp-install:
 init: npm-install gulp-install
 
 .PHONY: test
-test:
+test: test-unit
+
+.PHONY: test-unit
+test-unit:
 	npm run test
 
 .PHONY: package


### PR DESCRIPTION
This change will allow any future tests to be easily added to the Makefile (for example if you would like to add integration tests).