### PR TITLE
Fix for registered office address always appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1474,8 +1474,8 @@
       }
     },
     "ch-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#48ef881262cd297e8ba48f6e8646178ff7c0310e",
-      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#48ef881262cd297e8ba48f6e8646178ff7c0310e",
+      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0e6445e83fedb1e766b25c84c7c194b19a402904",
+      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0e6445e83fedb1e766b25c84c7c194b19a402904",
       "requires": {
         "camelcase-keys": "^6.2.2",
         "request": "^2.88.0",

--- a/src/controllers/check.details.controller.ts
+++ b/src/controllers/check.details.controller.ts
@@ -63,7 +63,7 @@ export const mapIncludedOnCertificate = (itemOptions: ItemOptions): string => {
         mappings.push(GOOD_STANDING)
     }
 
-    if (itemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType?.length !==0) {
+    if (itemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType != undefined) {
         mappings.push(REGISTERED_OFFICE_ADDRESS)
     }
 

--- a/src/test/controllers/check.details.controller.spec.unit.ts
+++ b/src/test/controllers/check.details.controller.spec.unit.ts
@@ -71,7 +71,7 @@ describe("mapIncludedOnCertificate", () => {
     it("should map the no values when all options are false", () => {
 
         itemOptions.includeGoodStandingInformation = false;
-        itemOptions.registeredOfficeAddressDetails.includeAddressRecordsType = "";
+        delete itemOptions.registeredOfficeAddressDetails.includeAddressRecordsType;
         itemOptions.directorDetails.includeBasicInformation = false;
         itemOptions.secretaryDetails.includeBasicInformation = false;
         itemOptions.includeCompanyObjectsInformation = false;


### PR DESCRIPTION
When not provided registered office address is `undefined` rather than an empty string