### PR TITLE
Add fix for company numbers displaying as phone numbers on ios devices

### DIFF
--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -15,6 +15,7 @@
 {% from "./components/footer/macro.njk"               import chFooter %}
 
 {% block head %}
+<meta name="format-detection" content="telephone=no">
 <!--[if !IE 8]><!-->
 <link rel="stylesheet" type="text/css" media="all" href="{{ CSS_URL }}" />
 <link rel="stylesheet" type="text/css" media="all" href="{{ FOOTER }}" />


### PR DESCRIPTION
When displayed on an IOS device numbers such as the company number on the check details screen are showing as phone numbers. This PR fixes the issue.