### PR TITLE
Fix/GCI-860: Add functionality to switch between both service names

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,14 @@ import authCertificateMiddleware from "./middleware/certificates/auth.middleware
 import authCertifiedCopyMiddleware from "./middleware/certified-copies/auth.middleware";
 
 import {
-    PIWIK_SITE_ID, PIWIK_URL, COOKIE_SECRET, COOKIE_DOMAIN, CACHE_SERVER, APPLICATION_NAME
+    PIWIK_SITE_ID,
+    PIWIK_URL,
+    COOKIE_SECRET,
+    COOKIE_DOMAIN,
+    CACHE_SERVER,
+    APPLICATION_NAME,
+    SERVICE_NAME_CERTIFICATES,
+    SERVICE_NAME_CERTIFIED_COPIES
 } from "./config/config";
 
 const app = express();
@@ -57,6 +64,17 @@ app.use(pageUrls.ROOT_CERTIFICATE_ID, authCertificateMiddleware);
 
 app.use([pageUrls.ROOT_CERTIFIED_COPY, pageUrls.ROOT_CERTIFIED_COPY_ID], SessionMiddleware(cookieConfig, sessionStore));
 app.use(pageUrls.ROOT_CERTIFIED_COPY_ID, authCertifiedCopyMiddleware);
+
+app.use((req, res, next) => {
+  if(req.path.includes('/certificates')) {
+    env.addGlobal("SERVICE_NAME", SERVICE_NAME_CERTIFICATES);
+  } else if(req.path.includes('/certified-copies')) {
+    env.addGlobal("SERVICE_NAME", SERVICE_NAME_CERTIFIED_COPIES);
+  } else {
+    env.addGlobal("SERVICE_NAME", SERVICE_NAME_GENERIC);
+  }
+  next();
+});
 
 app.set("views", viewPath);
 app.set("view engine", "html");

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -27,4 +27,4 @@ export const APPLICATION_NAME = "certificates.orders.web.ch.gov.uk";
 
 export const SERVICE_NAME_CERTIFIED_COPIES = "Order a certified document";
 
-export const SERVICE_NAME_CERTIFICATE = "Order a certificate";
+export const SERVICE_NAME_CERTIFICATES = "Order a certificate";

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -27,4 +27,4 @@ export const APPLICATION_NAME = "certificates.orders.web.ch.gov.uk";
 
 export const SERVICE_NAME_CERTIFIED_COPIES = "Order a certified document";
 
-export const SERVICE_NAME_CERTIFICATE = "Order a certicate";
+export const SERVICE_NAME_CERTIFICATE = "Order a certificate";

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,3 +28,5 @@ export const APPLICATION_NAME = "certificates.orders.web.ch.gov.uk";
 export const SERVICE_NAME_CERTIFIED_COPIES = "Order a certified document";
 
 export const SERVICE_NAME_CERTIFICATES = "Order a certificate";
+
+export const SERVICE_NAME_GENERIC = "";

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,3 +24,7 @@ export const CHS_URL = getEnvironmentValue("CHS_URL");
 export const COOKIE_DOMAIN = getEnvironmentValue("COOKIE_DOMAIN");
 
 export const APPLICATION_NAME = "certificates.orders.web.ch.gov.uk";
+
+export const SERVICE_NAME_CERTIFIED_COPIES = "Order a certified document";
+
+export const SERVICE_NAME_CERTIFICATE = "Order a certicate";

--- a/src/controllers/certified-copies/home.controller.ts
+++ b/src/controllers/certified-copies/home.controller.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from "express";
 import { CERTIFIED_COPY_FILING_HISTORY, replaceCompanyNumber } from "../../model/page.urls";
 import { CERTIFIED_COPY_INDEX } from "../../model/template.paths";
-import { CHS_URL } from "../../config/config";
+import { CHS_URL, SERVICE_NAME_CERTIFIED_COPIES } from "../../config/config";
 
 export default (req: Request, res: Response) => {
     const companyNumber: string = req.params.companyNumber;
     const startNowUrl = `${CHS_URL}${replaceCompanyNumber(CERTIFIED_COPY_FILING_HISTORY, companyNumber)}`;
-    const serviceName: string = "Order a certified document";
+    const serviceName: string = SERVICE_NAME_CERTIFIED_COPIES;
     res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber, serviceName });
 };

--- a/src/controllers/certified-copies/home.controller.ts
+++ b/src/controllers/certified-copies/home.controller.ts
@@ -6,5 +6,6 @@ import { CHS_URL } from "../../config/config";
 export default (req: Request, res: Response) => {
     const companyNumber: string = req.params.companyNumber;
     const startNowUrl = `${CHS_URL}${replaceCompanyNumber(CERTIFIED_COPY_FILING_HISTORY, companyNumber)}`;
-    res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber });
+    const serviceName: string = "Order a certified document";
+    res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber, serviceName });
 };

--- a/src/controllers/certified-copies/home.controller.ts
+++ b/src/controllers/certified-copies/home.controller.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from "express";
 import { CERTIFIED_COPY_FILING_HISTORY, replaceCompanyNumber } from "../../model/page.urls";
 import { CERTIFIED_COPY_INDEX } from "../../model/template.paths";
-import { CHS_URL, SERVICE_NAME_CERTIFIED_COPIES } from "../../config/config";
+import { CHS_URL } from "../../config/config";
 
 export default (req: Request, res: Response) => {
     const companyNumber: string = req.params.companyNumber;
     const startNowUrl = `${CHS_URL}${replaceCompanyNumber(CERTIFIED_COPY_FILING_HISTORY, companyNumber)}`;
-    const serviceName: string = SERVICE_NAME_CERTIFIED_COPIES;
-    res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber, serviceName });
+    res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber });
 };

--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -36,7 +36,7 @@
   {% include "includes/cookie-banner.html" %}
   {{ chHeader({
     homepageUrl: "/",
-    serviceName: "Order a certificate",
+    serviceName: serviceName if serviceName else "Order a certificate",
     serviceUrl: "/company/" + companyNumber + "/orderable/certificates",
     containerClasses: "govuk-width-container",
     assetPath: ""

--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -36,7 +36,7 @@
   {% include "includes/cookie-banner.html" %}
   {{ chHeader({
     homepageUrl: "/",
-    serviceName: serviceName if serviceName else "Order a certificate",
+    serviceName: SERVICE_NAME,
     serviceUrl: "/company/" + companyNumber + "/orderable/certificates",
     containerClasses: "govuk-width-container",
     assetPath: ""


### PR DESCRIPTION
Adds ability to include either a `Order a certificate` or  a `Order a certified document` service name in the service header.