### PR TITLE
Fix/GCI-860: Add missing service name  import

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,8 @@ import {
     CACHE_SERVER,
     APPLICATION_NAME,
     SERVICE_NAME_CERTIFICATES,
-    SERVICE_NAME_CERTIFIED_COPIES
+    SERVICE_NAME_CERTIFIED_COPIES,
+    SERVICE_NAME_GENERIC
 } from "./config/config";
 
 const app = express();


### PR DESCRIPTION
Add missing service name  import: `SERVICE_NAME_GENERIC`