### PR TITLE
Feature/GCI-1228: Delete the  the 'remove document' calls-to-action

### DIFF
--- a/src/views/certified-copies/check-details.html
+++ b/src/views/certified-copies/check-details.html
@@ -68,7 +68,7 @@
                           <th scope="col" class="govuk-table__header">Type</th>
                           <th scope="col" class="govuk-table__header govuk-!-width-half">Description</th>
                           <th scope="col" class="govuk-table__header">Fee</th>
-                          <th scope="col" class="govuk-table__header"></th>
+
                       </tr>
                     </thead>
                     <tbody class="govuk-table__body">
@@ -77,25 +77,25 @@
                             <td class="govuk-table__cell">AP01</td>
                             <td class="govuk-table__cell">Appointment of Ms Sharon Michelle White as a director on 4 February 2020</td>
                             <td class="govuk-table__cell">£15</td>
-                            <td class="govuk-table__cell"><a href="#" class="govuk-link">Remove</a></td>
+
                         </tr>
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">07 Feb 2020</td>
                             <td class="govuk-table__cell">AP03</td>
                             <td class="govuk-table__cell">Appointment of Mr Peter Simpson as a secretary on 31 January 2018.</td>
                             <td class="govuk-table__cell">£15</td>
-                            <td class="govuk-table__cell"><a href="#" class="govuk-link">Remove</a></td>
+
                         </tr>
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><h4 class="govuk-heading-s">Total</h4></td>
                             <td class="govuk-table__cell"></td>
                             <td class="govuk-table__cell"></td>
                             <td class="govuk-table__cell"><h4 class="govuk-heading-s">£30</h4></td>
-                            <td class="govuk-table__cell"></td>
+
                         </tr>
                     </tbody>
                 </table>
-                <a href="/filter-document-list" class="govuk-body govuk-link">Add document</a> <br><br>
+                <p class="govuk-body">To make any changes, you must <a href="#" class="govuk-body govuk-link">start the order again</a>.</p>
                 <a href="https://products.payments.service.gov.uk/pay/60317897263e405d963cdb92a76deffa" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
                 Continue to payment
                 </a>


### PR DESCRIPTION
Removes the links for "deleting a document"