### PR TITLE
Display error page if company should not be able to order a certificate in the node app

### DIFF
--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -4,6 +4,7 @@ import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
 import { getCompanyProfile } from "../../client/api.client";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME, API_KEY } from "../../config/config";
+import { YOU_CANNOT_USE_THIS_SERVICE } from "../../model/template.paths";
 import createError from "http-errors";
 
 const logger = createLogger(APPLICATION_NAME);
@@ -33,7 +34,8 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         if (allow && companyStatus === "active") {
             res.render("certificates/index", { startNowUrl, companyNumber });
         } else {
-            throw createError("Cannot order certificate for company type");
+            const SERVICE_NAME = null;
+            res.render(YOU_CANNOT_USE_THIS_SERVICE, { SERVICE_NAME });
         };
     } catch (err) {
         logger.error(`${err}`);

--- a/src/model/template.paths.ts
+++ b/src/model/template.paths.ts
@@ -1,9 +1,12 @@
 const certRoot = "certificates";
 const certifiedCopyRoot = "certified-copies";
+const errorRoot = "error-pages";
 
 export const GOOD_STANDING: string = "good-standing";
 export const COLLECTION: string = "collection";
 export const DELIVERY_DETAILS: string = "delivery-details";
+
+export const YOU_CANNOT_USE_THIS_SERVICE: string = `${errorRoot}/you-cannot-use-this-service`;
 
 export const CERTIFICATE_INDEX: string = `${certRoot}/index`;
 export const CERTIFICATE_OPTIONS: string = `${certRoot}/options`;

--- a/src/views/error-pages/you-cannot-use-this-service.html
+++ b/src/views/error-pages/you-cannot-use-this-service.html
@@ -1,0 +1,22 @@
+  
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  You cannot use this service
+{% endblock %}
+
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">You cannot use this service</h1>
+        <p class="govuk-body">
+          You cannot order a certificate or certified document for this company.   
+        </p>
+
+        <a href="https://beta.companieshouse.gov.uk/" class="govuk-link">Return to the Companies House service</a>
+
+    </div>
+  </div>
+{% endblock %}

--- a/test/controller/certificates/home.controller.integration.test.ts
+++ b/test/controller/certificates/home.controller.integration.test.ts
@@ -54,7 +54,7 @@ const dummyCompanyProfileAcceptableCompanyType: Resource<CompanyProfile> = {
 };
 
 const dummyCompanyProfileNotAcceptableCompanyType: Resource<CompanyProfile> = {
-    httpStatusCode: 500,
+    httpStatusCode: 200,
     resource: {
         companyName: "company name",
         companyNumber: "00000000",
@@ -124,7 +124,7 @@ describe("certificate.home.controller.integration", () => {
         const resp = await chai.request(testApp)
             .get(replaceCompanyNumber(ROOT_CERTIFICATE, COMPANY_NUMBER));
 
-        chai.expect(resp.status).to.equal(500);
-        chai.expect(resp.text).to.contain("Error");
+        chai.expect(resp.status).to.equal(200);
+        chai.expect(resp.text).to.contain("You cannot order a certificate or certified document for this company. ");
     });
 });


### PR DESCRIPTION
Add error view 
Update controller to redirect to error page 
Update test

Resolves: GCI-1295