### PR TITLE
Add blank actions to fix google lighthouse accessibility issue

### DIFF
--- a/src/views/certificates/check-details.html
+++ b/src/views/certificates/check-details.html
@@ -31,6 +31,13 @@
                   },
                   value: {
                     text: companyName
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "company name"
+                      }
+                    ]
                   }
                 },
                 {
@@ -39,6 +46,13 @@
                   },
                   value: {
                     text: companyNumber
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "company number"
+                      }
+                    ]
                   }
                 },
                 {
@@ -47,6 +61,13 @@
                   },
                   value: {
                     text: certificateType
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "certificate type"
+                      }
+                    ]
                   }
                 },
                  {
@@ -72,6 +93,13 @@
                   },
                   value: {
                     text: deliveryMethod
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "delivery method"
+                      }
+                    ]
                   }
                 },
                 {
@@ -97,6 +125,13 @@
                   },
                   value: {
                     text: fee
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "fee"
+                      }
+                    ]
                   }
                 }
               ]


### PR DESCRIPTION
Google lighthouse accessibility report produced the following message:
`<dl>'s do not contain only properly-ordered <dt> and <dd> groups, <script>, <template> or <div> elements.`

This was due to where actions were not present `span` elements were added. This is flagged by lighthouse as a `dl` should not contain a span.

Blank actions allow the span to be placed inside a `dd` element.

Resolves: GCI-1350