### PR TITLE
Update texts on order a certified copy of document in a company's fil…

### DIFF
--- a/src/views/certified-copies/check-details.html
+++ b/src/views/certified-copies/check-details.html
@@ -92,7 +92,7 @@
                       </tr>
                     </tbody>
                 </table>
-                <p class="govuk-body">To make any changes to the documents selected, <a href="/company/{{companyNumber}}/certified-documents" class="govuk-body govuk-link">start the order again</a>.</p>
+                <p class="govuk-body">To select a different document, <a href="/company/{{companyNumber}}/certified-documents" class="govuk-body govuk-link">start the order again</a>.</p>
                 {{ govukButton({
                   text: "Continue to payment",
                   id: "submit"

--- a/src/views/certified-copies/index.html
+++ b/src/views/certified-copies/index.html
@@ -17,17 +17,14 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">Order a certified document</h1>
             <p class="govuk-body-l">
-                Use this service to order certified copies of documents in a company's filing history.
-            </p>
-            <p class="govuk-body">
-                You can order more than one certified document using this service.
+                Use this service to order a certified copy of a document in a company's filing history.
             </p>
             <p class="govuk-body">You'll need:</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>to sign in to or create a Companies House account</li>
                 <li>a debit or credit card</li>
             </ul>
-            <p class="govuk-body">Ordering certified documents takes around 5 minutes.</p>
+            <p class="govuk-body">Ordering a certified document takes around 5 minutes.</p>
 
             {{ govukButton({
               text: "Start now",
@@ -43,7 +40,7 @@
             <h2 class="govuk-heading-m">Fee</h2>
 
             <p class="govuk-body">
-                It costs £15 for each certified document with standard delivery.
+                It costs £15 for a certified document with standard delivery.
             </p>
             <p class="govuk-body">
               Incorporation orders cost £30 and include 2 certified documents, the memorandum and articles. We will include the IN01 or an equivalent document if the memorandum or articles are not available.


### PR DESCRIPTION
[GCI-1399](https://companieshouse.atlassian.net/browse/GCI-1399)   Update texts on order a certified copy of document in a company's filing history
- from "Use this service to order certified copies of documents in a company's filing history" -> to "Use this service to order a certified copy of a document in a company's filing history"
- Removed " You can order more than one certified document using this service."
- from "Ordering certified documents takes around 5 minutes" -> to "Ordering a certified document takes around 5 minutes"
- from "It costs £15 for each certified document with standard delivery" -> to "It costs £15 for a certified document with standard delivery"
- from "To make any changes to the documents selected" -> to "To select a different document"