### PR TITLE
use ch npm for ch session handler import and usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,186 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@companieshouse/node-session-handler": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-4.1.5.tgz",
+      "integrity": "sha512-DyWZr1DXpgaBJGiSl+Gw0B+snC+gaSqVR9OlqimdMHhdsKm2W33+Nypr83Cint+Xj4VVDLX0BQv0o/8PMJWjCg==",
+      "requires": {
+        "@companieshouse/structured-logging-node": "~1.0.0",
+        "crypto": "^1.0.1",
+        "express-async-handler": "^1.1.4",
+        "ioredis": "^4.17.3",
+        "msgpack5": "^4.2.1",
+        "on-headers": "^1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ioredis": {
+          "version": "4.19.2",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.19.2.tgz",
+          "integrity": "sha512-SZSIwMrbd96b7rJvJwyTWSP6XQ0m1kAIIqBnwglJKrIJ6na7TeY4F2EV2vDY0xm/fLrUY8cEg81dR7kVFt2sKA==",
+          "requires": {
+            "cluster-key-slot": "^1.1.0",
+            "debug": "^4.1.1",
+            "denque": "^1.1.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.flatten": "^4.4.0",
+            "p-map": "^2.1.0",
+            "redis-commands": "1.6.0",
+            "redis-errors": "^1.2.0",
+            "redis-parser": "^3.0.0",
+            "standard-as-callback": "^2.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "redis-commands": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+          "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
+        }
+      }
+    },
+    "@companieshouse/structured-logging-node": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@companieshouse/structured-logging-node/-/structured-logging-node-1.0.4.tgz",
+      "integrity": "sha512-SNY0R7PQB8pECJfJAK/6kTdjy5OrQ0dI8vZ2A0qRkD7f/8k4T7sji/cuuQyNRf4sR2sqAVGGff9NsI9w8Vqhuw==",
+      "requires": {
+        "moment": "~2.29.0",
+        "on-finished": "~2.3.0",
+        "winston": "~3.3.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "fecha": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+          "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "logform": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+          "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+          "requires": {
+            "colors": "^1.2.1",
+            "fast-safe-stringify": "^2.0.4",
+            "fecha": "^4.2.0",
+            "ms": "^2.1.1",
+            "triple-beam": "^1.3.0"
+          }
+        },
+        "moment": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "one-time": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+          "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+          "requires": {
+            "fn.name": "1.x.x"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "winston": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+          "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+          "requires": {
+            "@dabh/diagnostics": "^2.0.2",
+            "async": "^3.1.0",
+            "is-stream": "^2.0.0",
+            "logform": "^2.2.0",
+            "one-time": "^1.0.0",
+            "readable-stream": "^3.4.0",
+            "stack-trace": "0.0.x",
+            "triple-beam": "^1.3.0",
+            "winston-transport": "^4.4.0"
+          }
+        },
+        "winston-transport": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+          "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+          "requires": {
+            "readable-stream": "^2.3.7",
+            "triple-beam": "^1.2.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      },
+      "dependencies": {
+        "enabled": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+          "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "kuler": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+          "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1355,58 +1535,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "ch-node-session-handler": {
-      "version": "git+ssh://git@github.com/companieshouse/node-session-handler.git#fd890c30d4dc253beaa8cd65182962ecb3691c16",
-      "from": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.1",
-      "requires": {
-        "ch-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
-        "crypto": "^1.0.1",
-        "express-async-handler": "^1.1.4",
-        "ioredis": "^4.16.3",
-        "msgpack5": "^4.2.1",
-        "on-headers": "^1.0.2"
-      },
-      "dependencies": {
-        "ch-logging": {
-          "version": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
-          "from": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
-          "requires": {
-            "moment": "~2.26.0",
-            "on-finished": "~2.3.0",
-            "winston": "~3.2.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ioredis": {
-          "version": "4.17.3",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
-          "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
-          "requires": {
-            "cluster-key-slot": "^1.1.0",
-            "debug": "^4.1.1",
-            "denque": "^1.1.0",
-            "lodash.defaults": "^4.2.0",
-            "lodash.flatten": "^4.4.0",
-            "redis-commands": "1.5.0",
-            "redis-errors": "^1.2.0",
-            "redis-parser": "^3.0.0",
-            "standard-as-callback": "^2.0.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
     },
     "ch-sdk-node": {
       "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#1eb0ac36ff037a6f34e9097accb769d855503656",
@@ -3099,6 +3227,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -6757,6 +6890,11 @@
       "requires": {
         "p-limit": "^2.0.0"
       }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-try": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/node-session-handler": "~4.1.0",
+    "@companieshouse/node-session-handler": "~4.1.5",
     "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.28",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.1",
+    "@companieshouse/node-session-handler": "~4.1.0",
     "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.28",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "~1.4.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import nunjucks from "nunjucks";
 import path from "path";
 import cookieParser from "cookie-parser";
 import Redis from "ioredis";
-import { SessionStore, SessionMiddleware, CookieConfig } from "ch-node-session-handler";
+import { SessionStore, SessionMiddleware, CookieConfig } from "@companieshouse/node-session-handler";
 
 import certRouter from "./routers/certificates/routers";
 import certCopyRouter from "./routers/certified-copies/routers";

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { CERTIFICATE_TYPE, replaceCompanyNumber } from "./../model/page.urls";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME } from "../config/config";

--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from "express";
-import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 
 import { getCertificateItem } from "../../client/api.client";
 import { CERTIFICATE_OPTIONS, replaceCertificateId, DISSOLVED_CERTIFICATE_DELIVERY_DETAILS } from "./../../model/page.urls";

--- a/src/middleware/certified-copies/auth.middleware.ts
+++ b/src/middleware/certified-copies/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from "express";
-import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { getUserId } from "../../session/helper";
 import { CERTIFIED_COPY_DELIVERY_DETAILS, replaceCertifiedCopyId } from "../../model/page.urls";
 

--- a/src/middleware/missing-image-deliveries/auth.middleware.ts
+++ b/src/middleware/missing-image-deliveries/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from "express";
-import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { getUserId } from "../../session/helper";
 import { MISSING_IMAGE_DELIVERY_CREATE, replaceCompanyNumberAndFilingHistoryId } from "../../model/page.urls";
 import { createLogger } from "ch-structured-logging";

--- a/src/session/helper.ts
+++ b/src/session/helper.ts
@@ -1,6 +1,6 @@
-import { SessionKey } from "ch-node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "ch-node-session-handler/lib/session/keys/SignInInfoKeys";
-import { UserProfileKeys } from "ch-node-session-handler/lib/session/keys/UserProfileKeys";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
+import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/session/keys/UserProfileKeys";
 
 export const getAccessToken = (session): string => {
     const signInInfo = session?.data[SessionKey.SignInInfo];

--- a/test/__mocks__/redis.mocks.ts
+++ b/test/__mocks__/redis.mocks.ts
@@ -1,4 +1,4 @@
-import { Encoding } from "ch-node-session-handler/lib/encoding/Encoding";
+import { Encoding } from "@companieshouse/node-session-handler/lib/encoding/Encoding";
 
 const SIGNED_IN_ID = "4ZhJ6pAmB5NAJbjy/6fU1DWMqqrk";
 const SIGNED_IN_SIGNATURE = "Ak4CCqkfPTY7VN6f9Lo5jHCUYpM";

--- a/test/controller/certificates/check.details.controller.integration.test.ts
+++ b/test/controller/certificates/check.details.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
-import sessionHandler from "ch-node-session-handler";
+import sessionHandler from "@companieshouse/node-session-handler";
 import { BasketItem, Basket } from "ch-sdk-node/dist/services/order/basket/types";
 import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
 

--- a/test/controller/certificates/check.details.controller.unit.test.ts
+++ b/test/controller/certificates/check.details.controller.unit.test.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import sessionHandler from "ch-node-session-handler";
+import sessionHandler from "@companieshouse/node-session-handler";
 import {
     ItemOptions, RegisteredOfficeAddressDetails, DirectorOrSecretaryDetails
 } from "ch-sdk-node/dist/services/order/certificates/types";

--- a/test/controller/certificates/options.controller.unit.test.ts
+++ b/test/controller/certificates/options.controller.unit.test.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import sessionHandler from "ch-node-session-handler"; // need this to allow certificate.options.controller to compile
+import sessionHandler from "@companieshouse/node-session-handler"; // need this to allow certificate.options.controller to compile
 
 import { setItemOptions } from "../../../src/controllers/certificates/options.controller";
 

--- a/test/controller/certified-copies/check.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/check.details.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
-import sessionHandler from "ch-node-session-handler";
+import sessionHandler from "@companieshouse/node-session-handler";
 import { Basket, BasketItem } from "ch-sdk-node/dist/services/order/basket/types";
 import { CertifiedCopyItem } from "ch-sdk-node/dist/services/order/certified-copies/types";
 

--- a/test/middleware/auth.middleware.unit.test.ts
+++ b/test/middleware/auth.middleware.unit.test.ts
@@ -1,8 +1,8 @@
 import chai from "chai";
 import sinon from "sinon";
 import { Request, Response } from "express";
-import SessionHandler from "ch-node-session-handler";
-import { Session } from "ch-node-session-handler/lib/session/model/Session";
+import SessionHandler from "@companieshouse/node-session-handler";
+import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 
 import authMiddleware from "../../src/middleware/auth.middleware";
 

--- a/test/middleware/certificates/auth.middleware.unit.test.ts
+++ b/test/middleware/certificates/auth.middleware.unit.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import sinon from "sinon";
 import { Request, Response } from "express";
-import { Session } from "ch-node-session-handler/lib/session/model/Session";
+import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
 
 import certificateAuthMiddleware from "../../../src/middleware/certificates/auth.middleware";

--- a/test/middleware/certified-copies/auth.middleware.unit.test.ts
+++ b/test/middleware/certified-copies/auth.middleware.unit.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import sinon from "sinon";
 import { Request, Response } from "express";
-import { Session } from "ch-node-session-handler/lib/session/model/Session";
+import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 
 import certifiedCopyAuthMiddleware from "../../../src/middleware/certified-copies/auth.middleware";
 import * as apiClient from "../../../src/client/api.client";

--- a/test/middleware/missing-image-deliveries/auth.middleware.unit.test.ts
+++ b/test/middleware/missing-image-deliveries/auth.middleware.unit.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import sinon from "sinon";
 import { Request, Response } from "express";
-import { Session } from "ch-node-session-handler/lib/session/model/Session";
+import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 
 import missingImageDeliveryAuthMiddleware from "../../../src/middleware/missing-image-deliveries/auth.middleware";
 import * as apiClient from "../../../src/client/api.client";

--- a/test/utils/check.details.utils.unit.test.ts
+++ b/test/utils/check.details.utils.unit.test.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import sessionHandler from "ch-node-session-handler";
+import sessionHandler from "@companieshouse/node-session-handler";
 import {
     ItemOptions, RegisteredOfficeAddressDetails, DirectorOrSecretaryDetails
 } from "ch-sdk-node/dist/services/order/certificates/types";


### PR DESCRIPTION
Updated version of ch session handler by importing the npm repo of the ch session handler, no longer using the git repo.

Resolves: BI-6119