### PR TITLE
add logic for back button delivery details page 

### DIFF
--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -18,12 +18,9 @@ const ADDRESS_TOWN_FIELD: string = "addressTown";
 const ADDRESS_COUNTY_FIELD: string = "addressCounty";
 const ADDRESS_POSTCODE_FIELD: string = "addressPostcode";
 const ADDRESS_COUNTRY_FIELD: string = "addressCountry";
+let backLink;
 
 const logger = createLogger(APPLICATION_NAME);
-
-const setBackLink = (certificateItem: CertificateItem) => {
-    return (certificateItem.itemOptions?.certificateType !== "dissolution") ? "certificate-options" : `/company/${certificateItem.companyNumber}/orderable/dissolved-certificates`;
-};
 
 export const render = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -116,6 +113,17 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
         logger.error(`${err}`);
         return next(err);
     }
+};
+
+export const setBackLink = (certificateItem: CertificateItem) => {
+    if (certificateItem.itemOptions?.certificateType === "dissolution") {
+        backLink = `/company/${certificateItem.companyNumber}/orderable/dissolved-certificates`;
+    } else if (certificateItem.itemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType) {
+        backLink = "registered-office-options";
+    } else {
+        backLink = "certificate-options";
+    }
+    return backLink;
 };
 
 export default [...deliveryDetailsValidationRules, route];

--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -18,7 +18,6 @@ const ADDRESS_TOWN_FIELD: string = "addressTown";
 const ADDRESS_COUNTY_FIELD: string = "addressCounty";
 const ADDRESS_POSTCODE_FIELD: string = "addressPostcode";
 const ADDRESS_COUNTRY_FIELD: string = "addressCountry";
-let backLink;
 
 const logger = createLogger(APPLICATION_NAME);
 

--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -116,6 +116,8 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 export const setBackLink = (certificateItem: CertificateItem) => {
+    let backLink;
+    
     if (certificateItem.itemOptions?.certificateType === "dissolution") {
         backLink = `/company/${certificateItem.companyNumber}/orderable/dissolved-certificates`;
     } else if (certificateItem.itemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType) {

--- a/test/controller/certificates/delivery.details.controller.unit.test.ts
+++ b/test/controller/certificates/delivery.details.controller.unit.test.ts
@@ -1,0 +1,42 @@
+import chai from "chai";
+
+import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { setBackLink } from "../../../src/controllers/certificates/delivery.details.controller";
+import { mockDissolvedCertificateItem } from "../../__mocks__/certificates.mocks";
+
+describe("delivery.details.controller.unit", () => {
+    describe("setBackUrl for no registered address option selected", () => {
+        it("the back button link should take the user to the certificate options page", () => {
+            const certificateItem = {
+                itemOptions: {
+                    forename: "john",
+                    surname: "smith"
+                }
+            } as CertificateItem;
+
+            chai.expect(setBackLink(certificateItem)).to.equal("certificate-options");
+        });
+    });
+
+    describe("setBackUrl for registered office option selected", () => {
+        it("the back button link should take the user to the registered office option page", () => {
+            const certificateItem = {
+                itemOptions: {
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    }
+                }
+            } as CertificateItem;
+
+            chai.expect(setBackLink(certificateItem)).to.equal("registered-office-options");
+        });
+    });
+
+    describe("setBackUrl for dissolved certificate", () => {
+        it("the back button link should take the user to the start page for dissolved certificate", () => {
+            const certificateItem = mockDissolvedCertificateItem as CertificateItem;
+
+            chai.expect(setBackLink(mockDissolvedCertificateItem)).to.include("/orderable/dissolved-certificates");
+        });
+    });
+});


### PR DESCRIPTION
Determines if the back button should take the user to the cert option page or the registered office options page when ordering a certificate.

Resolves: BI-6028