### PR TITLE
revert radio button option retention implement default reg office option

### DIFF
--- a/src/controllers/certificates/options.controller.ts
+++ b/src/controllers/certificates/options.controller.ts
@@ -93,6 +93,7 @@ export const setItemOptions = (options: string[]): ItemOptionsRequest => {
                 break;
             }
             case REGISTERED_OFFICE_FIELD: {
+                itemOptionsAccum.registeredOfficeAddressDetails = { includeAddressRecordsType: "current" };
                 break;
             }
             case DIRECTORS_FIELD: {

--- a/src/controllers/certificates/registered.office.options.controller.ts
+++ b/src/controllers/certificates/registered.office.options.controller.ts
@@ -21,14 +21,12 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
     const accessToken: string = getAccessToken(req.session);
     const certificateItem: CertificateItem = await getCertificateItem(accessToken, req.params.certificateId);
     const itemOptions: ItemOptions = certificateItem.itemOptions;
-    const regOfficeAddressDetails: RegisteredOfficeAddressDetails = itemOptions?.registeredOfficeAddressDetails;
     const SERVICE_URL = `/company/${certificateItem.companyNumber}/orderable/certificates`;
 
     logger.info(`Certificate item retrieved, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
 
     return res.render(CERTIFICATE_REGISTERED_OFFICE_OPTIONS, {
         companyNumber: certificateItem.companyNumber,
-        regOfficeAddressDetails,
         SERVICE_URL
     });
 };

--- a/src/views/certificates/registered-office-options.html
+++ b/src/views/certificates/registered-office-options.html
@@ -46,7 +46,6 @@
               {
                 value: "currentAddress",
                 text: "Current address",
-                checked: true if regOfficeAddressDetails.includeAddressRecordsType == "current" else false,
                 attributes: {
                   "data-event-id" : "certificate-reg-office-address-current"
                 }
@@ -54,7 +53,6 @@
               {
                 value: "currentAddressAndTheOnePrevious",
                 text: "Current address and the one previous",
-                checked: true if regOfficeAddressDetails.includeAddressRecordsType == "current-and-previous" else false,
                 attributes: {
                   "data-event-id" : "certificate-reg-office-address-current-previous"
                 }
@@ -62,7 +60,6 @@
               {
                 value: "currentAddressAndTheTwoPrevious",
                 text: "Current address and the two previous",
-                checked: true if regOfficeAddressDetails.includeAddressRecordsType == "current-previous-and-prior" else false,
                 attributes: {
                   "data-event-id" : "certificate-reg-office-address-current-two-previous"
                 }
@@ -70,7 +67,6 @@
               {
                 value: "allCurrentAndPreviousAddresses",
                 text: "All current and previous addresses",
-                checked: true if regOfficeAddressDetails.includeAddressRecordsType == "all" else false,
                 attributes: {
                   "data-event-id" : "certificate-reg-office-address-all"
                 }

--- a/test/controller/certificates/options.controller.unit.test.ts
+++ b/test/controller/certificates/options.controller.unit.test.ts
@@ -30,7 +30,7 @@ describe("certificate.options.controller.unit", () => {
             const options = ["registeredOffice"];
             const returnedItemOptions = setItemOptions(options);
 
-            chai.expect(returnedItemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType).to.equal(null);
+            chai.expect(returnedItemOptions?.registeredOfficeAddressDetails?.includeAddressRecordsType).to.equal("current");
         });
 
         it("should set includeBasicInformation on secretaryDetails to true, when the option is secretaries", () => {


### PR DESCRIPTION
Reverted radio button retention on reg office details page. This allows for retention of the reg office option on the main options page to display when a user goes backwards through the journey.

Resolves: BI-6395