### PR TITLE
Migrate from ch-sdk-node to api-sdk-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,66 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@companieshouse/api-sdk-node": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.16.tgz",
+      "integrity": "sha512-H6K3LvjolEr98tMcMIIlyCOBZFt5jqazJ4/TM8Y2PB78Sqh8Dso1mE5UQz3m2EH8Yj3OSW7FrfSkuepVLY6Ekw==",
+      "requires": {
+        "camelcase-keys": "~6.2.2",
+        "request": "~2.88.2",
+        "request-promise-native": "~1.0.9",
+        "snakecase-keys": "~3.2.0"
+      },
+      "dependencies": {
+        "camelcase-keys": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+          "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+          "requires": {
+            "camelcase": "^5.3.1",
+            "map-obj": "^4.0.0",
+            "quick-lru": "^4.0.1"
+          }
+        },
+        "map-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+          "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        }
+      }
+    },
     "@companieshouse/node-session-handler": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-4.1.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.16.tgz",
-      "integrity": "sha512-H6K3LvjolEr98tMcMIIlyCOBZFt5jqazJ4/TM8Y2PB78Sqh8Dso1mE5UQz3m2EH8Yj3OSW7FrfSkuepVLY6Ekw==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.17.tgz",
+      "integrity": "sha512-q5DZhEARc8ea8JitkCnHZMukXg86Uh6oHOfqW/A5MP4siyvckT9JkQ4GWcI+3JKMnOuXTV6gfwUHzzXj2R5DRA==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -1595,33 +1595,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "ch-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#6571ff2267a5ee9f93298d0abda62021c70407b4",
-      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.32",
-      "requires": {
-        "camelcase-keys": "~6.2.2",
-        "request": "~2.88.0",
-        "request-promise-native": "~1.0.8",
-        "snakecase-keys": "~3.2.0"
-      },
-      "dependencies": {
-        "camelcase-keys": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-          "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-          "requires": {
-            "camelcase": "^5.3.1",
-            "map-obj": "^4.0.0",
-            "quick-lru": "^4.0.1"
-          }
-        },
-        "map-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-          "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
-        }
-      }
     },
     "ch-structured-logging": {
       "version": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
@@ -7594,6 +7567,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -7620,17 +7594,20 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@companieshouse/api-sdk-node": "^1.0.16",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.32",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.16",
+    "@companieshouse/api-sdk-node": "^1.0.17",
     "@companieshouse/node-session-handler": "~4.1.6",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.32",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "~1.4.4",
     "express": "~4.17.1",

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -1,13 +1,13 @@
-import { createApiClient } from "ch-sdk-node";
-import { CompanyProfile, CompanyProfileResource } from "ch-sdk-node/dist/services/company-profile";
-import { BasketItem, ItemUriPostRequest, Basket, BasketPatchRequest } from "ch-sdk-node/dist/services/order/basket/types";
-import { CertificateItemPostRequest, CertificateItemPatchRequest, CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
-import { CertifiedCopyItem, CertifiedCopyItemResource } from "ch-sdk-node/dist/services/order/certified-copies/types";
+import { createApiClient } from "@companieshouse/api-sdk-node";
+import { CompanyProfile, CompanyProfileResource } from "@companieshouse/api-sdk-node/dist/services/company-profile";
+import { BasketItem, ItemUriPostRequest, Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { CertificateItemPostRequest, CertificateItemPatchRequest, CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { CertifiedCopyItem, CertifiedCopyItemResource } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
 import { API_KEY, API_URL, APPLICATION_NAME } from "../config/config";
 import { createLogger } from "ch-structured-logging";
-import Resource from "ch-sdk-node/dist/services/resource";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
 import createError from "http-errors";
-import { MidItemPostRequest, MidItem } from "ch-sdk-node/dist/services/order/mid/types";
+import { MidItemPostRequest, MidItem } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 
 const logger = createLogger(APPLICATION_NAME);
 

--- a/src/controllers/certificates/check.details.controller.ts
+++ b/src/controllers/certificates/check.details.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-import { CertificateItem, ItemOptions, DirectorOrSecretaryDetails } from "ch-sdk-node/dist/services/order/certificates/types";
-import { Basket, DeliveryDetails } from "ch-sdk-node/dist/services/order/basket/types";
+import { CertificateItem, ItemOptions, DirectorOrSecretaryDetails } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { Basket, DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import { createLogger } from "ch-structured-logging";
 
 import { CERTIFICATE_OPTIONS, CERTIFICATE_DELIVERY_DETAILS, replaceCertificateId } from "../../model/page.urls";

--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { CertificateItem, CertificateItemPatchRequest } from "ch-sdk-node/dist/services/order/certificates/types";
-import { Basket, BasketPatchRequest } from "ch-sdk-node/dist/services/order/basket/types";
+import { CertificateItem, CertificateItemPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import { getAccessToken, getUserId } from "../../session/helper";
 import { getCertificateItem, patchCertificateItem, getBasket, patchBasket } from "../../client/api.client";
 import { DELIVERY_DETAILS, CERTIFICATE_CHECK_DETAILS } from "../../model/template.paths";

--- a/src/controllers/certificates/director.options.controller.ts
+++ b/src/controllers/certificates/director.options.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { getAccessToken, getUserId } from "../../session/helper";
-import { CertificateItem, ItemOptions, DirectorOrSecretaryDetails, DirectorOrSecretaryDetailsRequest, CertificateItemPatchRequest } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem, ItemOptions, DirectorOrSecretaryDetails, DirectorOrSecretaryDetailsRequest, CertificateItemPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { getCertificateItem, patchCertificateItem } from "../../client/api.client";
 import { CERTIFICATE_DIRECTOR_OPTIONS } from "../../model/template.paths";
 import { createLogger } from "ch-structured-logging";

--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { DISSOLVED_CERTIFICATE_TYPE, CERTIFICATE_TYPE, replaceCompanyNumber } from "../../model/page.urls";
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
 import { getCompanyProfile } from "../../client/api.client";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME, API_KEY } from "../../config/config";

--- a/src/controllers/certificates/options.controller.ts
+++ b/src/controllers/certificates/options.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { CertificateItemPatchRequest, ItemOptionsRequest, CertificateItem, ItemOptions } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItemPatchRequest, ItemOptionsRequest, CertificateItem, ItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { patchCertificateItem, getCertificateItem } from "../../client/api.client";
 import { createLogger } from "ch-structured-logging";
 import { CERTIFICATE_OPTIONS } from "../../model/template.paths";

--- a/src/controllers/certificates/registered.office.options.controller.ts
+++ b/src/controllers/certificates/registered.office.options.controller.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import { CERTIFICATE_REGISTERED_OFFICE_OPTIONS } from "../../model/template.paths";
-import { CertificateItem, RegisteredOfficeAddressDetailsRequest, CertificateItemPatchRequest, ItemOptions, RegisteredOfficeAddressDetails } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem, RegisteredOfficeAddressDetailsRequest, CertificateItemPatchRequest, ItemOptions, RegisteredOfficeAddressDetails } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { getCertificateItem, patchCertificateItem } from "../../client/api.client";
 import { getAccessToken, getUserId } from "../../session/helper";
 import { createLogger } from "ch-structured-logging";

--- a/src/controllers/certificates/secretary.options.controller.ts
+++ b/src/controllers/certificates/secretary.options.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { getAccessToken } from "../../session/helper";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { getCertificateItem } from "../../client/api.client";
 import { CERTIFICATE_SECRETARY_OPTIONS } from "../../model/template.paths";
 

--- a/src/controllers/certificates/type.controller.ts
+++ b/src/controllers/certificates/type.controller.ts
@@ -1,12 +1,12 @@
 import { Request, Response, NextFunction } from "express";
 
 import { getAccessToken, getUserId } from "../../session/helper";
-import { CertificateItemPostRequest, CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItemPostRequest, CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { postCertificateItem, getCompanyProfile } from "../../client/api.client";
 import { CERTIFICATE_OPTIONS, replaceCertificateId, DISSOLVED_CERTIFICATE_DELIVERY_DETAILS } from "./../../model/page.urls";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME, API_KEY } from "../../config/config";
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile/types";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 
 const logger = createLogger(APPLICATION_NAME);
 const INCORPORATION_WITH_ALL_NAME_CHANGES: string = "incorporation-with-all-name-changes";

--- a/src/controllers/certified-copies/check.details.controller.ts
+++ b/src/controllers/certified-copies/check.details.controller.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { createLogger } from "ch-structured-logging";
-import { CertifiedCopyItem, FilingHistoryDocuments } from "ch-sdk-node/dist/services/order/certified-copies";
-import { Basket } from "ch-sdk-node/dist/services/order/basket";
+import { CertifiedCopyItem, FilingHistoryDocuments } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies";
+import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket";
 
 import { CERTIFIED_COPY_DELIVERY_DETAILS, replaceCertifiedCopyId } from "../../model/page.urls";
 import { CERTIFIED_COPY_CHECK_DETAILS } from "../../model/template.paths";

--- a/src/controllers/certified-copies/delivery.details.controller.ts
+++ b/src/controllers/certified-copies/delivery.details.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { Basket, BasketPatchRequest } from "ch-sdk-node/dist/services/order/basket/types";
+import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import { createLogger } from "ch-structured-logging";
 
 import { getAccessToken, getUserId } from "../../session/helper";
@@ -8,7 +8,7 @@ import { DELIVERY_DETAILS } from "../../model/template.paths";
 import { APPLICATION_NAME } from "../../config/config";
 import { getBasket, patchBasket, getCertifiedCopyItem } from "../../client/api.client";
 import { deliveryDetailsValidationRules, validate } from "../../utils/delivery-details-validation";
-import { CertifiedCopyItem } from "ch-sdk-node/dist/services/order/certified-copies/types";
+import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
 
 const FIRST_NAME_FIELD: string = "firstName";
 const LAST_NAME_FIELD: string = "lastName";

--- a/src/controllers/certified-copies/home.controller.ts
+++ b/src/controllers/certified-copies/home.controller.ts
@@ -4,7 +4,7 @@ import { CERTIFIED_COPY_INDEX, YOU_CANNOT_USE_THIS_SERVICE } from "../../model/t
 import { CHS_URL, API_KEY, APPLICATION_NAME } from "../../config/config";
 import { getCompanyProfile } from "../../client/api.client";
 import { createLogger } from "ch-structured-logging";
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
 import createError from "http-errors";
 
 const logger = createLogger(APPLICATION_NAME);

--- a/src/controllers/missing-image-deliveries/check.details.controller.ts
+++ b/src/controllers/missing-image-deliveries/check.details.controller.ts
@@ -3,7 +3,7 @@ import { MISSING_IMAGE_DELIVERY_CHECK_DETAILS } from "../../model/template.paths
 import { getAccessToken, getUserId } from "../../session/helper";
 import { APPLICATION_NAME, CHS_URL } from "../../config/config";
 import { createLogger } from "ch-structured-logging";
-import { MidItem } from "ch-sdk-node/dist/services/order/mid/types";
+import { MidItem } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 import { getMissingImageDeliveryItem, addItemToBasket } from "../../client/api.client";
 import { getFullFilingHistoryDescription } from "../../config/api.enumerations";
 import { replaceCompanyNumberAndFilingHistoryId, ROOT_MISSING_IMAGE_DELIVERY } from "../../model/page.urls";

--- a/src/controllers/missing-image-deliveries/create.missing.image.delivery.item.controller.ts
+++ b/src/controllers/missing-image-deliveries/create.missing.image.delivery.item.controller.ts
@@ -4,7 +4,7 @@ import { postMissingImageDeliveryItem } from "../../client/api.client";
 import { MISSING_IMAGE_DELIVERY_CHECK_DETAILS, replaceMissingImageDeliveryId } from "../../model/page.urls";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME } from "../../config/config";
-import { MidItem, MidItemPostRequest } from "ch-sdk-node/dist/services/order/mid/types";
+import { MidItem, MidItemPostRequest } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 
 const logger = createLogger(APPLICATION_NAME);
 

--- a/src/utils/check.details.utils.ts
+++ b/src/utils/check.details.utils.ts
@@ -1,4 +1,4 @@
-import { DeliveryDetails } from "ch-sdk-node/dist/services/order/basket/types";
+import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 export const mapDeliveryDetails = (deliveryDetails: DeliveryDetails | undefined): string => {
     const mappings:string[] = [];

--- a/src/utils/service.url.utils.ts
+++ b/src/utils/service.url.utils.ts
@@ -1,4 +1,4 @@
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 export const setServiceUrl = (certificateItem: CertificateItem) => {
     return (certificateItem.itemOptions?.certificateType !== "dissolution")

--- a/test/__mocks__/certificates.mocks.ts
+++ b/test/__mocks__/certificates.mocks.ts
@@ -1,6 +1,6 @@
-import Resource from "ch-sdk-node/dist/services/resource";
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 export const mockCompanyProfileConfiguration: any = {
     companyNumber: "00000000"

--- a/test/__mocks__/company.profile.mocks.ts
+++ b/test/__mocks__/company.profile.mocks.ts
@@ -1,5 +1,5 @@
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile/types";
-import Resource from "ch-sdk-node/dist/services/resource";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
 
 export const dummyCompanyProfileActiveCompany: CompanyProfile = {
     companyName: "company name",

--- a/test/client/api.client.unit.test.ts
+++ b/test/client/api.client.unit.test.ts
@@ -1,18 +1,18 @@
 import sinon from "sinon";
 import chai from "chai";
-import Resource from "ch-sdk-node/dist/services/resource";
-import CertificateItemService from "ch-sdk-node/dist/services/order/certificates/service";
-import BasketService from "ch-sdk-node/dist/services/order/basket/service";
-import CertifiedCopyItemService from "ch-sdk-node/dist/services/order/certified-copies/service";
-import { CertificateItemPostRequest, CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
-import { CertifiedCopyItem, CertifiedCopyItemResource } from "ch-sdk-node/dist/services/order/certified-copies/types";
-import { Basket, BasketPatchRequest } from "ch-sdk-node/dist/services/order/basket/types";
+import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
+import CertificateItemService from "@companieshouse/api-sdk-node/dist/services/order/certificates/service";
+import BasketService from "@companieshouse/api-sdk-node/dist/services/order/basket/service";
+import CertifiedCopyItemService from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/service";
+import { CertificateItemPostRequest, CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { CertifiedCopyItem, CertifiedCopyItemResource } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
+import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import { postCertificateItem, patchBasket, getBasket, getCompanyProfile, getCertifiedCopyItem, postMissingImageDeliveryItem, getMissingImageDeliveryItem } from "../../src/client/api.client";
-import CompanyProfileService from "ch-sdk-node/dist/services/company-profile/service";
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile/types";
-import { MidService } from "ch-sdk-node/dist/services/order";
-import { MidItem, MidItemPostRequest } from "ch-sdk-node/dist/services/order/mid/types";
+import CompanyProfileService from "@companieshouse/api-sdk-node/dist/services/company-profile/service";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { MidService } from "@companieshouse/api-sdk-node/dist/services/order";
+import { MidItem, MidItemPostRequest } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 
 const dummyBasketSDKResponse: Resource<Basket> = {
     httpStatusCode: 200,

--- a/test/controller/certificates/check.details.controller.integration.test.ts
+++ b/test/controller/certificates/check.details.controller.integration.test.ts
@@ -3,8 +3,8 @@ import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
 import sessionHandler from "@companieshouse/node-session-handler";
-import { BasketItem, Basket } from "ch-sdk-node/dist/services/order/basket/types";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { BasketItem, Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_CHECK_DETAILS, replaceCertificateId } from "../../../src/model/page.urls";

--- a/test/controller/certificates/check.details.controller.unit.test.ts
+++ b/test/controller/certificates/check.details.controller.unit.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sessionHandler from "@companieshouse/node-session-handler";
 import {
     ItemOptions, RegisteredOfficeAddressDetails, DirectorOrSecretaryDetails
-} from "ch-sdk-node/dist/services/order/certificates/types";
+} from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 import {
     mapCertificateType, applyCurrencySymbol, isOptionSelected, mapRegisteredOfficeAddress, mapDirectorOptions

--- a/test/controller/certificates/delivery.details.controller.integration.test.ts
+++ b/test/controller/certificates/delivery.details.controller.integration.test.ts
@@ -2,8 +2,8 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
-import { Basket } from "ch-sdk-node/dist/services/order/basket/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_DELIVERY_DETAILS, replaceCertificateId } from "../../../src/model/page.urls";

--- a/test/controller/certificates/delivery.details.controller.unit.test.ts
+++ b/test/controller/certificates/delivery.details.controller.unit.test.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
 
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { setBackLink } from "../../../src/controllers/certificates/delivery.details.controller";
 import { mockDissolvedCertificateItem } from "../../__mocks__/certificates.mocks";
 

--- a/test/controller/certificates/director.options.controller.integration.test.ts
+++ b/test/controller/certificates/director.options.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_DIRECTOR_OPTIONS, replaceCertificateId } from "../../../src/model/page.urls";
 

--- a/test/controller/certificates/director.options.controller.unit.test.ts
+++ b/test/controller/certificates/director.options.controller.unit.test.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { setBackLink, setDirectorOption } from "../../../src/controllers/certificates/director.options.controller";
 
 describe("director.options.controller.unit", () => {

--- a/test/controller/certificates/home.controller.integration.test.ts
+++ b/test/controller/certificates/home.controller.integration.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import ioredis from "ioredis";
 
 import { ROOT_CERTIFICATE, replaceCompanyNumber } from "../../../src/model/page.urls";
-import CompanyProfileService from "ch-sdk-node/dist/services/company-profile/service";
+import CompanyProfileService from "@companieshouse/api-sdk-node/dist/services/company-profile/service";
 import { dummyCompanyProfileAcceptableCompanyType, dummyCompanyProfileNotAcceptableCompanyType } from "../../__mocks__/company.profile.mocks";
 
 import {

--- a/test/controller/certificates/options.controller.integration.test.ts
+++ b/test/controller/certificates/options.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_OPTIONS, replaceCertificateId } from "../../../src/model/page.urls";

--- a/test/controller/certificates/registered.office.options.integration.test.ts
+++ b/test/controller/certificates/registered.office.options.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_REGISTERED_OFFICE_OPTIONS, replaceCertificateId } from "../../../src/model/page.urls";
 

--- a/test/controller/certificates/secretary.options.controller.integration.test.ts
+++ b/test/controller/certificates/secretary.options.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_SECRETARY_OPTIONS, replaceCertificateId } from "../../../src/model/page.urls";
 

--- a/test/controller/certificates/type.controller.integration.test.ts
+++ b/test/controller/certificates/type.controller.integration.test.ts
@@ -5,7 +5,7 @@ import ioredis from "ioredis";
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFICATE_TYPE, replaceCertificateId } from "../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { dummyCompanyProfileActiveCompany, dummyCompanyProfileDissolvedCompany } from "../../__mocks__/company.profile.mocks";
 
 const sandbox = sinon.createSandbox();

--- a/test/controller/certified-copies/check.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/check.details.controller.integration.test.ts
@@ -3,8 +3,8 @@ import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
 import sessionHandler from "@companieshouse/node-session-handler";
-import { Basket, BasketItem } from "ch-sdk-node/dist/services/order/basket/types";
-import { CertifiedCopyItem } from "ch-sdk-node/dist/services/order/certified-copies/types";
+import { Basket, BasketItem } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
 
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFIED_COPY_CHECK_DETAILS, replaceCertifiedCopyId } from "../../../src/model/page.urls";

--- a/test/controller/certified-copies/delivery.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/delivery.details.controller.integration.test.ts
@@ -5,9 +5,9 @@ import ioredis from "ioredis";
 import { CERTIFIED_COPY_DELIVERY_DETAILS, replaceCertifiedCopyId } from "../../../src/model/page.urls";
 import * as errorMessages from "../../../src/model/error.messages";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { Basket } from "ch-sdk-node/dist/services/order/basket/types";
+import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import * as apiClient from "../../../src/client/api.client";
-import { CertifiedCopyItem } from "ch-sdk-node/dist/services/order/certified-copies/types";
+import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
 
 const ENTER_YOUR_FIRST_NAME_NOT_INPUT = "Enter your first name";
 const ENTER_YOUR_LAST_NAME_NOT_INPUT = "Enter your last name";

--- a/test/controller/certified-copies/home.controller.integration.test.ts
+++ b/test/controller/certified-copies/home.controller.integration.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import { ROOT_CERTIFIED_COPY, replaceCompanyNumber } from "../../../src/model/page.urls";
-import CompanyProfileService from "ch-sdk-node/dist/services/company-profile/service";
+import CompanyProfileService from "@companieshouse/api-sdk-node/dist/services/company-profile/service";
 
 const COMPANY_NUMBER = "00000000";
 

--- a/test/controller/missing-image-deliveries/check.details.controller.integration.test.ts
+++ b/test/controller/missing-image-deliveries/check.details.controller.integration.test.ts
@@ -2,8 +2,8 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 import cheerio from "cheerio";
-import { MidItem } from "ch-sdk-node/dist/services/order/mid/types";
-import { Basket, BasketItem } from "ch-sdk-node/dist/services/order/basket/types";
+import { MidItem } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
+import { Basket, BasketItem } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import { MISSING_IMAGE_DELIVERY_CHECK_DETAILS, replaceMissingImageDeliveryId } from "../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";

--- a/test/controller/missing-image-deliveries/create.scud.item.controller.integration.test.ts
+++ b/test/controller/missing-image-deliveries/create.scud.item.controller.integration.test.ts
@@ -5,7 +5,7 @@ import ioredis from "ioredis";
 import * as apiClient from "../../../src/client/api.client";
 import { MISSING_IMAGE_DELIVERY_CREATE, replaceCompanyNumberAndFilingHistoryId } from "../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { MidItem } from "ch-sdk-node/dist/services/order/mid/types";
+import { MidItem } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 
 const FILING_HISTORY_ID = "MzAwOTM2MDg5OWFkaXF6a2N4";
 const COMPANY_NUMBER = "00006500";

--- a/test/controller/missing-image-delivery/create.missing.image.delivery.item.controller.integration.test.ts
+++ b/test/controller/missing-image-delivery/create.missing.image.delivery.item.controller.integration.test.ts
@@ -5,7 +5,7 @@ import ioredis from "ioredis";
 import * as apiClient from "../../../src/client/api.client";
 import { MISSING_IMAGE_DELIVERY_CREATE, replaceCompanyNumberAndFilingHistoryId } from "../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
-import { MidItem } from "ch-sdk-node/dist/services/order/mid/types";
+import { MidItem } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 
 const FILING_HISTORY_ID = "MzAwOTM2MDg5OWFkaXF6a2N4";
 const COMPANY_NUMBER = "00006500";

--- a/test/middleware/certificates/auth.middleware.unit.test.ts
+++ b/test/middleware/certificates/auth.middleware.unit.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import sinon from "sinon";
 import { Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 import certificateAuthMiddleware from "../../../src/middleware/certificates/auth.middleware";
 import * as apiClient from "../../../src/client/api.client";

--- a/test/utils/check.details.utils.unit.test.ts
+++ b/test/utils/check.details.utils.unit.test.ts
@@ -2,8 +2,8 @@ import chai from "chai";
 import sessionHandler from "@companieshouse/node-session-handler";
 import {
     ItemOptions, RegisteredOfficeAddressDetails, DirectorOrSecretaryDetails
-} from "ch-sdk-node/dist/services/order/certificates/types";
-import { DeliveryDetails } from "ch-sdk-node/dist/services/order/basket/types";
+} from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import {
     mapDeliveryDetails, mapDeliveryMethod, mapToHtml

--- a/test/utils/service.url.utils.test.ts
+++ b/test/utils/service.url.utils.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import { setServiceUrl } from "../../src/utils/service.url.utils";
 import { mockDissolvedCertificateItem } from "../__mocks__/certificates.mocks";
-import { CertificateItem } from "ch-sdk-node/dist/services/order/certificates/types";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 
 const certificateItem: CertificateItem = mockDissolvedCertificateItem;
 


### PR DESCRIPTION
Certificates web was still using the deprecated sdk which was slightly ahead with changes than the `api-sdk-node`. A new version with the changes was created and now the service can be migrated