### PR TITLE
Update set items so that all fields are covered in the initial item for directors

### DIFF
--- a/src/controllers/certificates/options.controller.ts
+++ b/src/controllers/certificates/options.controller.ts
@@ -79,7 +79,13 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 export const setItemOptions = (options: string[]): ItemOptionsRequest => {
     const initialItemOptions: ItemOptionsRequest = {
         directorDetails: {
-            includeBasicInformation: null
+            includeBasicInformation: null,
+            includeAddress: null,
+            includeAppointmentDate: null,
+            includeCountryOfResidence: null,
+            includeDobType: null,
+            includeNationality: null,
+            includeOccupation: null
         },
         includeCompanyObjectsInformation: null,
         includeGoodStandingInformation: null,


### PR DESCRIPTION
When a user returns to the page after selecting the options in the directors screen and then removes the option in the options page, the options selected would remain. Adding the following allows for a clean slate on starting the order again.

Resolves: BI-6017