### PR TITLE
remove unused initial sec options

### DIFF
--- a/src/controllers/certificates/secretary.options.controller.ts
+++ b/src/controllers/certificates/secretary.options.controller.ts
@@ -59,11 +59,7 @@ export const setSecretaryOption = (options: string[]): DirectorOrSecretaryDetail
     const initialSecretaryOptions: DirectorOrSecretaryDetailsRequest = {
         includeAddress: false,
         includeAppointmentDate: false,
-        includeBasicInformation: true,
-        includeCountryOfResidence: false,
-        includeDobType: null,
-        includeNationality: false,
-        includeOccupation: false
+        includeBasicInformation: true
     };
     return options === undefined ? initialSecretaryOptions
         : options.reduce((secretaryOptionsAccum: DirectorOrSecretaryDetailsRequest, option: string) => {


### PR DESCRIPTION
Removed unused options in setting up initial secretary options as these options were persisting if s customer selected and then unselected the secretary options.

Resolves: BI-6203