### PR TITLE
Bi 6452 retain secretary option checked boxes

### DIFF
--- a/src/controllers/certificates/secretary.options.controller.ts
+++ b/src/controllers/certificates/secretary.options.controller.ts
@@ -22,6 +22,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
     return res.render(CERTIFICATE_SECRETARY_OPTIONS, {
         companyNumber: certificateItem.companyNumber,
         backLink,
+        secretaryDetails: certificateItem.itemOptions?.secretaryDetails,
         SERVICE_URL
     });
 };
@@ -59,11 +60,7 @@ export const setSecretaryOption = (options: string[]): DirectorOrSecretaryDetail
     const initialSecretaryOptions: DirectorOrSecretaryDetailsRequest = {
         includeAddress: false,
         includeAppointmentDate: false,
-        includeBasicInformation: true,
-        includeCountryOfResidence: false,
-        includeDobType: null,
-        includeNationality: false,
-        includeOccupation: false
+        includeBasicInformation: true
     };
     return options === undefined ? initialSecretaryOptions
         : options.reduce((secretaryOptionsAccum: DirectorOrSecretaryDetailsRequest, option: string) => {

--- a/src/views/certificates/secretary-options.html
+++ b/src/views/certificates/secretary-options.html
@@ -39,6 +39,7 @@
             {
               value: "address",
               text: "Correspondence address",
+              checked: true if secretaryDetails.includeAddress else false,
               attributes: {
                 "data-event-id": "certificate-secretary-corr-addr"
               }
@@ -46,6 +47,7 @@
             {
               value: "appointment",
               text: "Appointment date",
+              checked: true if secretaryDetails.includeAppointmentDate else false,
               attributes: {
                 "data-event-id": "certificate-secretary-appt-date"
               }

--- a/test/controller/certificates/secretary.options.controller.integration.test.ts
+++ b/test/controller/certificates/secretary.options.controller.integration.test.ts
@@ -1,6 +1,7 @@
 import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
+import cheerio from "cheerio";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
 import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import * as apiClient from "../../../src/client/api.client";
@@ -15,6 +16,16 @@ const sandbox = sinon.createSandbox();
 let testApp = null;
 let getCertificateItemStub;
 let patchCertificateItemStub;
+
+const secretaryDetailsCertificateItem = {
+    itemOptions: {
+        secretaryDetails: {
+            includeAddress: false,
+            includeAppointmentDate: true,
+            includeBasicInformation: true
+        }
+    }
+} as CertificateItem;
 
 describe("secretary.options.integration.test", () => {
     beforeEach((done) => {
@@ -62,13 +73,29 @@ describe("secretary.options.integration.test", () => {
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
                 .redirects(0)
                 .send({
-                    includeAddress: false,
-                    includeAppointmentDate: true,
+                    includeAddress: true,
+                    includeAppointmentDate: false,
                     includeBasicInformation: true,
                 });
 
             chai.expect(resp.status).to.equal(302);
             chai.expect(resp.text).to.include("Found. Redirecting to delivery-details");
+        });
+    });
+    describe("Check the secretary page renders and retains checked boxes", () => {
+        it("renders the secretary options page with previously selected options checked", async () => {
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(secretaryDetailsCertificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(SECRETARY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($("#secretary-options").prop("checked")).be.false;
+            chai.expect($("#secretary-options-2").prop("checked")).be.true;
         });
     });
 });

--- a/test/controller/certificates/secretary.options.controller.integration.test.ts
+++ b/test/controller/certificates/secretary.options.controller.integration.test.ts
@@ -75,7 +75,7 @@ describe("secretary.options.integration.test", () => {
                 .send({
                     includeAddress: true,
                     includeAppointmentDate: false,
-                    includeBasicInformation: true,
+                    includeBasicInformation: true
                 });
 
             chai.expect(resp.status).to.equal(302);


### PR DESCRIPTION
Retains a user's previously selected checkboxes on the secretary options page and displays those chosen options if a user revisits that page.

Resolves: BI-6452