### PR TITLE
add configurable dispatch time update tests

### DIFF
--- a/src/utils/check.details.utils.ts
+++ b/src/utils/check.details.utils.ts
@@ -1,4 +1,7 @@
 import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { DISPATCH_DAYS } from "../config/config";
+
+const dispatchDays: string = DISPATCH_DAYS;
 
 export const mapDeliveryDetails = (deliveryDetails: DeliveryDetails | undefined): string => {
     const mappings:string[] = [];
@@ -31,7 +34,7 @@ export const mapDeliveryDetails = (deliveryDetails: DeliveryDetails | undefined)
 
 export const mapDeliveryMethod = (itemOptions: Record<string, any>): string | null => {
     if (itemOptions?.deliveryTimescale === "standard") {
-        return "Standard delivery (aim to dispatch within 4 working days)";
+        return "Standard delivery (aim to dispatch within " + dispatchDays + " working days)";
     }
     if (itemOptions?.deliveryTimescale === "same-day") {
         return "Same Day";

--- a/test/controller/certified-copies/check.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/check.details.controller.integration.test.ts
@@ -86,7 +86,7 @@ describe("certified-copy.check.details.controller.integration", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect($("#companyNameValue").text().trim()).to.equal(certifiedCopyItem.companyName);
             chai.expect($("#companyNumberValue").text().trim()).to.equal(certifiedCopyItem.companyNumber);
-            chai.expect($("#deliveryMethodValue").text().trim()).to.equal("Standard delivery (aim to dispatch within 4 working days)");
+            chai.expect($("#deliveryMethodValue").text().trim()).to.equal("Standard delivery (aim to dispatch within 10 working days)");
             chai.expect($("#deliveryDetailsValue").text().trim()).to.equal("bob jones117 kings roadpontcannacantonglamorgancf5 4xbwales");
             chai.expect($("#filingHistoryDateValue1").text().trim()).to.equal("12 Feb 2010");
             chai.expect($("#filingHistoryTypeValue1").text().trim()).to.equal("CH01");

--- a/test/utils/check.details.utils.unit.test.ts
+++ b/test/utils/check.details.utils.unit.test.ts
@@ -83,7 +83,7 @@ describe("certificate.check.details.controller.unit", () => {
     describe("mapDeliveryMethod", () => {
         it("should map the standard delivery string when 'standard' is returned from API", () => {
             const returnedString: string | null = mapDeliveryMethod(itemOptions);
-            const expectedString: string = "Standard delivery (aim to dispatch within 4 working days)";
+            const expectedString: string = "Standard delivery (aim to dispatch within 10 working days)";
 
             chai.expect(returnedString).to.equal(expectedString);
         });


### PR DESCRIPTION
Add config dispatch time date to delivery method section on the check your order details page within the cert copies journey

Resolves: BI-7359