### PR TITLE
add config dispatch date update text on cert start now page

### DIFF
--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -3,7 +3,7 @@ import { DISSOLVED_CERTIFICATE_TYPE, CERTIFICATE_TYPE, replaceCompanyNumber } fr
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
 import { getCompanyProfile } from "../../client/api.client";
 import { createLogger } from "ch-structured-logging";
-import { APPLICATION_NAME, API_KEY } from "../../config/config";
+import { APPLICATION_NAME, API_KEY, DISPATCH_DAYS } from "../../config/config";
 import { YOU_CANNOT_USE_THIS_SERVICE } from "../../model/template.paths";
 import createError from "http-errors";
 
@@ -15,6 +15,8 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const companyProfile: CompanyProfile = await getCompanyProfile(API_KEY, companyNumber);
         const companyStatus = companyProfile.companyStatus;
         const companyType = companyProfile.type;
+        const dispatchDays: string = DISPATCH_DAYS;
+        const moreTabUrl: string = "/company/" + companyNumber + "/more";
         const acceptableCompanyTypes = [
             "limited-partnership",
             "llp",
@@ -41,7 +43,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const allow: boolean = acceptableCompanyTypes.some(type => type === companyType);
 
         if (allow && ["active", "dissolved"].includes(companyStatus)) {
-            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL });
+            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL, dispatchDays, moreTabUrl });
         } else {
             const SERVICE_NAME = null;
             res.render(YOU_CANNOT_USE_THIS_SERVICE, { SERVICE_NAME });

--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -15,8 +15,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const companyProfile: CompanyProfile = await getCompanyProfile(API_KEY, companyNumber);
         const companyStatus = companyProfile.companyStatus;
         const companyType = companyProfile.type;
-        const dispatchDays: string = DISPATCH_DAYS;
-        const moreTabUrl: string = "/company/" + companyNumber + "/more";
+        const moreTabUrl = "/company/" + companyNumber + "/more";
         const acceptableCompanyTypes = [
             "limited-partnership",
             "llp",
@@ -43,7 +42,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const allow: boolean = acceptableCompanyTypes.some(type => type === companyType);
 
         if (allow && ["active", "dissolved"].includes(companyStatus)) {
-            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL, dispatchDays, moreTabUrl });
+            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL, DISPATCH_DAYS, moreTabUrl });
         } else {
             const SERVICE_NAME = null;
             res.render(YOU_CANNOT_USE_THIS_SERVICE, { SERVICE_NAME });

--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -48,7 +48,7 @@
 
         <h2 class="govuk-heading-m">Fee</h2>
 
-        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ dispatchDays }} working days.</p>
+        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ DISPATCH_DAYS }} working days.</p>
 
         <p class="govuk-body"> You can pay by debit or credit card. You cannot pay using a Companies House account. </p>
 
@@ -78,7 +78,7 @@
 
         <h2 class="govuk-heading-m">Fee</h2>
 
-        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ dispatchDays }} working days.</p>
+        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ DISPATCH_DAYS }} working days.</p>
 
         <p class="govuk-body"> You can pay by debit or credit card. You cannot pay using a Companies House account. </p>
 

--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -29,6 +29,10 @@
           <li>company objects</li>
         </ul>
 
+        <div class="govuk-inset-text">
+          This certificate is different to the incorporation documents that were issued when the company was formed. Copies of these can be ordered through the <a href="{{ moreTabUrl }}" class='govuk-link'>Order a certified document service</a>.
+        </div>
+
         <p class="govuk-body">Ordering a certificate takes around 5 minutes.</p>
 
         {{ govukButton({
@@ -44,7 +48,7 @@
 
         <h2 class="govuk-heading-m">Fee</h2>
 
-        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within 4 working days.</p>
+        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ dispatchDays }} working days.</p>
 
         <p class="govuk-body"> You can pay by debit or credit card. You cannot pay using a Companies House account. </p>
 
@@ -74,7 +78,7 @@
 
         <h2 class="govuk-heading-m">Fee</h2>
 
-        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within 4 working days.</p>
+        <p class="govuk-body">Certificates cost £15 for standard delivery to a UK or international address. We will aim to dispatch the certificate within {{ dispatchDays }} working days.</p>
 
         <p class="govuk-body"> You can pay by debit or credit card. You cannot pay using a Companies House account. </p>
 

--- a/test/controller/certified-copies/check.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/check.details.controller.integration.test.ts
@@ -9,6 +9,7 @@ import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/or
 import * as apiClient from "../../../src/client/api.client";
 import { CERTIFIED_COPY_CHECK_DETAILS, replaceCertifiedCopyId } from "../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
+import { DISPATCH_DAYS } from "../../../src/config/config";
 
 const CERTIFIED_COPY_ID = "CCD-123456-123456";
 const ITEM_URI = "/orderable/certified-copies/CCD-123456-123456";
@@ -86,7 +87,7 @@ describe("certified-copy.check.details.controller.integration", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect($("#companyNameValue").text().trim()).to.equal(certifiedCopyItem.companyName);
             chai.expect($("#companyNumberValue").text().trim()).to.equal(certifiedCopyItem.companyNumber);
-            chai.expect($("#deliveryMethodValue").text().trim()).to.equal("Standard delivery (aim to dispatch within 10 working days)");
+            chai.expect($("#deliveryMethodValue").text().trim()).to.equal("Standard delivery (aim to dispatch within " + DISPATCH_DAYS + " working days)");
             chai.expect($("#deliveryDetailsValue").text().trim()).to.equal("bob jones117 kings roadpontcannacantonglamorgancf5 4xbwales");
             chai.expect($("#filingHistoryDateValue1").text().trim()).to.equal("12 Feb 2010");
             chai.expect($("#filingHistoryTypeValue1").text().trim()).to.equal("CH01");

--- a/test/utils/check.details.utils.unit.test.ts
+++ b/test/utils/check.details.utils.unit.test.ts
@@ -8,6 +8,7 @@ import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/orde
 import {
     mapDeliveryDetails, mapDeliveryMethod, mapToHtml
 } from "../../src/utils/check.details.utils";
+import { DISPATCH_DAYS } from "../../src/config/config";
 
 const directorDetails: DirectorOrSecretaryDetails = {
     includeAddress: true,
@@ -83,7 +84,7 @@ describe("certificate.check.details.controller.unit", () => {
     describe("mapDeliveryMethod", () => {
         it("should map the standard delivery string when 'standard' is returned from API", () => {
             const returnedString: string | null = mapDeliveryMethod(itemOptions);
-            const expectedString: string = "Standard delivery (aim to dispatch within 10 working days)";
+            const expectedString: string = "Standard delivery (aim to dispatch within " + DISPATCH_DAYS + " working days)";
 
             chai.expect(returnedString).to.equal(expectedString);
         });


### PR DESCRIPTION
Use configurable dispatch date to output processing time on certs and dissolved certs start now page

Resolves: BI-7073