### PR TITLE
Add notification banners to all start now pages to show company in context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,9 +4187,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
     },
     "graceful-fs": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cookie-parser": "~1.4.4",
     "express": "~4.17.1",
     "express-validator": "~6.3.0",
-    "govuk-frontend": "^3.11.0",
+    "govuk-frontend": "^3.13.0",
     "http-errors": "~1.7.3",
     "ioredis": "~4.16.0",
     "js-yaml": "^3.14.0",

--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -13,6 +13,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
     try {
         const companyNumber: string = req.params.companyNumber;
         const companyProfile: CompanyProfile = await getCompanyProfile(API_KEY, companyNumber);
+        const companyName : string = companyProfile.companyName;
         const companyStatus = companyProfile.companyStatus;
         const companyType = companyProfile.type;
         const moreTabUrl = "/company/" + companyNumber + "/more";
@@ -45,7 +46,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 
         if (allow && ["active", "dissolved"].includes(companyStatus)) {
             logger.debug(`Rendering certificates/index, company_status=${companyStatus}, start_now_url=${startNowUrl}, company_number=${companyNumber}, service_url=${SERVICE_URL}, dispatch_days=${DISPATCH_DAYS}, more_tab_url=${moreTabUrl}`);
-            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL, DISPATCH_DAYS, moreTabUrl });
+            res.render("certificates/index", { companyStatus, startNowUrl, companyNumber, SERVICE_URL, DISPATCH_DAYS, moreTabUrl, companyName });
         } else {
             const SERVICE_NAME = null;
             res.render(YOU_CANNOT_USE_THIS_SERVICE, { SERVICE_NAME });

--- a/src/controllers/certified-copies/home.controller.ts
+++ b/src/controllers/certified-copies/home.controller.ts
@@ -14,6 +14,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const companyNumber: string = req.params.companyNumber;
         const startNowUrl = `${CHS_URL}${replaceCompanyNumber(CERTIFIED_COPY_FILING_HISTORY, companyNumber)}`;
         const companyProfile: CompanyProfile = await getCompanyProfile(API_KEY, companyNumber);
+        const companyName : string = companyProfile.companyName;
         const companyType = companyProfile.type;
         const filingHistory = companyProfile.links.filingHistory;
         const SERVICE_URL = `/company/${companyNumber}/orderable/certified-copies`;
@@ -24,7 +25,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
             const SERVICE_NAME = null;
             res.render(YOU_CANNOT_USE_THIS_SERVICE, { SERVICE_NAME });
         } else {
-            res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber, SERVICE_URL, dispatchDays, moreTabUrl });
+            res.render(CERTIFIED_COPY_INDEX, { startNowUrl, companyNumber, SERVICE_URL, dispatchDays, moreTabUrl, companyName });
         }
     } catch (err) {
         logger.error(`${err}`);

--- a/src/controllers/missing-image-deliveries/home.controller.ts
+++ b/src/controllers/missing-image-deliveries/home.controller.ts
@@ -1,12 +1,17 @@
 import { Request, Response } from "express";
 import { MISSING_IMAGE_DELIVERY_INDEX } from "../../model/template.paths";
 import { MISSING_IMAGE_DELIVERY_CREATE, replaceCompanyNumberAndFilingHistoryId } from "../../model/page.urls";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
+import { getCompanyProfile } from "../../client/api.client";
+import { API_KEY } from "../../config/config";
 
 export default async (req: Request, res: Response) => {
     const companyNumber: string = req.params.companyNumber;
+    const companyProfile: CompanyProfile = await getCompanyProfile(API_KEY, companyNumber);
+    const companyName : string = companyProfile.companyName;
     const filingHistoryId: string = req.params.filingHistoryId;
     const startNowUrl: string = replaceCompanyNumberAndFilingHistoryId(MISSING_IMAGE_DELIVERY_CREATE, companyNumber, filingHistoryId);
     const SERVICE_URL = `/company/${companyNumber}/filing-history`;
 
-    res.render(MISSING_IMAGE_DELIVERY_INDEX, { companyNumber, startNowUrl, SERVICE_URL });
+    res.render(MISSING_IMAGE_DELIVERY_INDEX, { companyNumber, startNowUrl, SERVICE_URL, companyName });
 };

--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -1,5 +1,14 @@
 {% extends "layout.html" %}
 
+{% set notificationHtml %}
+  <p class="govuk-notification-banner__heading">
+    This order will be for {{ companyName }} ({{ companyNumber }}).
+    <p>If you want to order a certificate for a different company, you will need to
+    <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register,</a>
+    then use the 'More' tab on the company page to re-enter this service.</p>
+  </p>
+{% endset %}
+
 {% block pageTitle %}
   Order a certificate
 {% endblock %}
@@ -12,9 +21,15 @@
 {% endblock %}
 
 {% block content %}
+
+  {{ govukNotificationBanner({
+    html: notificationHtml
+  }) }}
+
   {% if companyStatus === "active" %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
+      
         <h1 class="govuk-heading-xl">Order a certificate</h1>
 
         <p class="govuk-body-l">Use this service to order a signed certificate of incorporation for a company, including all company name changes. </p>

--- a/src/views/certified-copies/index.html
+++ b/src/views/certified-copies/index.html
@@ -1,5 +1,14 @@
 {% extends "layout.html" %}
 
+{% set notificationHtml %}
+  <p class="govuk-notification-banner__heading">
+    This order will be for {{ companyName }} ({{ companyNumber }}).
+    <p>If you want to order a certified document for a different company, you will need to
+    <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register,</a>
+    then use the 'More' tab on the company page to re-enter this service.</p>
+  </p>
+{% endset %}
+
 {% block pageTitle %}
   Order a certified document
 {% endblock %}
@@ -12,6 +21,10 @@
 {% endblock %}
 
 {% block content %}
+
+  {{ govukNotificationBanner({
+    html: notificationHtml
+  }) }}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -1,19 +1,20 @@
 {% extends "components/template.njk" %}
 
-{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
-{% from "govuk/components/button/macro.njk"           import govukButton %}
-{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
-{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
-{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
-{% from "govuk/components/panel/macro.njk"            import govukPanel %}
-{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
-{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
-{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
-{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
-{% from "govuk/components/radios/macro.njk"           import govukRadios %}
-{% from "govuk/components/input/macro.njk"            import govukInput %}
-{% from "./components/header/macro.njk"               import chHeader %}
-{% from "./components/footer/macro.njk"               import chFooter %}
+{% from "govuk/components/breadcrumbs/macro.njk"          import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"               import govukButton %}
+{% from "govuk/components/back-link/macro.njk"            import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk"        import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"             import govukFieldset %}
+{% from "govuk/components/panel/macro.njk"                import govukPanel %}
+{% from "govuk/components/checkboxes/macro.njk"           import govukCheckboxes %}
+{% from "govuk/components/summary-list/macro.njk"         import govukSummaryList %}
+{% from "govuk/components/inset-text/macro.njk"           import govukInsetText %}
+{% from "govuk/components/textarea/macro.njk"             import govukTextarea %}
+{% from "govuk/components/radios/macro.njk"               import govukRadios %}
+{% from "govuk/components/input/macro.njk"                import govukInput %}
+{% from "govuk/components/notification-banner/macro.njk"  import govukNotificationBanner %}
+{% from "./components/header/macro.njk"                   import chHeader %}
+{% from "./components/footer/macro.njk"                   import chFooter %}
 
 {% block head %}
 <meta name="format-detection" content="telephone=no">

--- a/src/views/missing-image-deliveries/index.html
+++ b/src/views/missing-image-deliveries/index.html
@@ -1,5 +1,14 @@
 {% extends "layout.html" %}
 
+{% set notificationHtml %}
+  <p class="govuk-notification-banner__heading">
+    This order will be for {{ companyName }} ({{ companyNumber }}).
+    <p>If you want to request a document for a different company, you will need to
+    <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register.</a>
+    In the company's filing history, select 'Request document' for the document you require.</p>
+  </p>
+{% endset %}
+
 {% block pageTitle %}
  Request a document
 {% endblock %}
@@ -12,6 +21,10 @@
 {% endblock %}
 
 {% block content %}
+  {{ govukNotificationBanner({
+    html: notificationHtml
+  }) }}
+  
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Request a document</h1>

--- a/test/controller/certificates/home.controller.integration.test.ts
+++ b/test/controller/certificates/home.controller.integration.test.ts
@@ -43,6 +43,17 @@ describe("certificate.home.controller.integration", () => {
         chai.expect(resp.text).to.contain("Order a certificate");
     });
 
+    it("displays the notification banner with the in context company name and company number", async () => {
+        getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
+            .returns(Promise.resolve(dummyCompanyProfileAcceptableCompanyType));
+
+        const resp = await chai.request(testApp)
+            .get(replaceCompanyNumber(ROOT_CERTIFICATE, COMPANY_NUMBER));
+
+        chai.expect(resp.status).to.equal(200);
+        chai.expect(resp.text).to.contain("This order will be for company name (00000000)");
+    });
+
     it("does not render the start page if company type is not allowed to order a certificate", async () => {
         getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
             .returns(Promise.resolve(dummyCompanyProfileNotAcceptableCompanyType));

--- a/test/controller/certified-copies/home.controller.integration.test.ts
+++ b/test/controller/certified-copies/home.controller.integration.test.ts
@@ -77,6 +77,18 @@ describe("certified-copy.home.controller.integration", () => {
         chai.expect(resp.text).to.contain("Order a certified document");
     });
 
+    it("displays the notification banner with the in context company name and company number", async () => {
+        dummyCompanyProfile.resource.links.filingHistory = "/company/00000000/filing-history";
+        getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
+            .returns(Promise.resolve(dummyCompanyProfile));
+
+        const resp = await chai.request(testApp)
+            .get(replaceCompanyNumber(ROOT_CERTIFIED_COPY, COMPANY_NUMBER));
+
+        chai.expect(resp.status).to.equal(200);
+        chai.expect(resp.text).to.contain("This order will be for company name (00000000)");
+    });
+
     it("does not render the start now page as company has no filing history link", async () => {
         getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
             .returns(Promise.resolve(dummyCompanyProfile));

--- a/test/controller/missing-image-deliveries/home.controller.integration.test.ts
+++ b/test/controller/missing-image-deliveries/home.controller.integration.test.ts
@@ -2,14 +2,58 @@ import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
 
-import { ROOT_MISSING_IMAGE_DELIVERY } from "../../../src/model/page.urls";
+import { ROOT_MISSING_IMAGE_DELIVERY, replaceCompanyNumberAndFilingHistoryId } from "../../../src/model/page.urls";
+import CompanyProfileService from "@companieshouse/api-sdk-node/dist/services/company-profile/service";
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
+let dummyCompanyProfile;
+let getCompanyProfileStub;
 
 describe("missingImageDelivery.home.controller.integration", () => {
     beforeEach((done) => {
         sandbox.stub(ioredis.prototype, "connect").returns(Promise.resolve());
+        dummyCompanyProfile = {
+            httpStatusCode: 200,
+            resource: {
+                companyName: "company name",
+                companyNumber: "00000000",
+                companyStatus: "active",
+                companyStatusDetail: "company status detail",
+                dateOfCreation: "date of creation",
+                jurisdiction: "jurisdiction",
+                sicCodes: ["85100", "85200"],
+                hasBeenLiquidated: false,
+                type: "other",
+                hasCharges: false,
+                hasInsolvencyHistory: false,
+                registeredOfficeAddress: {
+                    addressLineOne: "line1",
+                    addressLineTwo: "line2",
+                    careOf: "careOf",
+                    country: "uk",
+                    locality: "locality",
+                    poBox: "123",
+                    postalCode: "post code",
+                    premises: "premises",
+                    region: "region"
+                },
+                accounts: {
+                    nextAccounts: {
+                        periodEndOn: "2019-10-10",
+                        periodStartOn: "2019-01-01"
+                    },
+                    nextDue: "2020-05-31",
+                    overdue: false
+                },
+                confirmationStatement: {
+                    nextDue: "2020-05-31",
+                    overdue: false
+                },
+                links: {
+                }
+            }
+        };
 
         testApp = require("../../../src/app").default;
         done();
@@ -21,10 +65,23 @@ describe("missingImageDelivery.home.controller.integration", () => {
     });
 
     it("renders the start page", async () => {
+        getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
+            .returns(Promise.resolve(dummyCompanyProfile));
+
         const resp = await chai.request(testApp)
             .get(ROOT_MISSING_IMAGE_DELIVERY);
 
         chai.expect(resp.status).to.equal(200);
         chai.expect(resp.text).to.contain("Request a document");
+    });
+
+    it("displays the notification banner with the in context company name and company number", async () => {
+        getCompanyProfileStub = sandbox.stub(CompanyProfileService.prototype, "getCompanyProfile")
+            .returns(Promise.resolve(dummyCompanyProfile));
+        const resp = await chai.request(testApp)
+            .get(replaceCompanyNumberAndFilingHistoryId(ROOT_MISSING_IMAGE_DELIVERY, "00000000", "mytxjsks"));
+
+        chai.expect(resp.status).to.equal(200);
+        chai.expect(resp.text).to.contain("This order will be for company name (00000000)");
     });
 });


### PR DESCRIPTION
Increment frontend kit package version
Update home controllers to pass company name to templates
Add notification banners to each start now page and display company name and company number
Update home page integration tests

Resolves: BI-1852 BI-1853 BI-1854