### PR TITLE
BI-9890 Options controller bypass company profile

### DIFF
--- a/test/controller/certificates/llp-certificates/options.controller.integration.test.ts
+++ b/test/controller/certificates/llp-certificates/options.controller.integration.test.ts
@@ -7,7 +7,6 @@ import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/orde
 import * as apiClient from "../../../../src/client/api.client";
 import { LLP_CERTIFICATE_OPTIONS, replaceCertificateId } from "../../../../src/model/page.urls";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../../__mocks__/redis.mocks";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile";
 
 const CERTIFICATE_ID = "CHS00000000000000001";
 const LLP_CERTIFICATE_OPTIONS_URL = replaceCertificateId(LLP_CERTIFICATE_OPTIONS, CERTIFICATE_ID);
@@ -16,26 +15,45 @@ const sandbox = sinon.createSandbox();
 let testApp = null;
 let getCertificateItemStub;
 let patchCertificateItemStub;
-let getCompanyProfileStub;
 
 describe("llp.certificate.options.controller.integration", () => {
-    const companyProfile = {
-        companyStatus: 'active'
-    } as CompanyProfile;
-
     const certificateItem = {
         itemOptions: {
-            directorDetails: {
+            companyStatus: "active",
+            designatedMemberDetails: {
                 includeBasicInformation: true
             },
-            includeCompanyObjectsInformation: true,
             includeGoodStandingInformation: true,
             registeredOfficeAddressDetails: {
                 includeAddressRecordsType: "current"
             },
-            secretaryDetails: {
+            memberDetails: {
                 includeBasicInformation: true
             }
+        }
+    } as CertificateItem;
+
+    const certificateItemLiquidated = {
+        itemOptions: {
+            companyStatus: "liquidation",
+            designatedMemberDetails: {
+                includeBasicInformation: true
+            },
+            registeredOfficeAddressDetails: {
+                includeAddressRecordsType: "current"
+            },
+            memberDetails: {
+                includeBasicInformation: true
+            },
+            liquidatorsDetails: {
+                includeBasicInformation: true
+            }
+        }
+    } as CertificateItem;
+
+    const certificateDetails = {
+        itemOptions: {
+            companyStatus: "active"
         }
     } as CertificateItem;
 
@@ -56,8 +74,6 @@ describe("llp.certificate.options.controller.integration", () => {
         it("renders the certificate options page", async () => {
             getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
                 .returns(Promise.resolve(certificateItem));
-            getCompanyProfileStub = sandbox.stub(apiClient, "getCompanyProfile")
-                .returns(Promise.resolve(companyProfile));
 
             const resp = await chai.request(testApp)
                 .get(LLP_CERTIFICATE_OPTIONS_URL)
@@ -68,17 +84,32 @@ describe("llp.certificate.options.controller.integration", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect($(".govuk-fieldset__heading").text().trim()).to
                 .equal("What information would you like to be included on the certificate?");
+            chai.expect($(".govuk-checkboxes__item").length).to.be.greaterThan(0);
+            chai.expect($(".govuk-checkboxes__item:first").find("label").text().trim()).to.equal("Statement of good standing");
+        });
+
+        it("renders the certificate options page for a liquidated company", async () => {
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItemLiquidated));
+
+            const resp = await chai.request(testApp)
+                .get(LLP_CERTIFICATE_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-fieldset__heading").text().trim()).to
+                .equal("What information would you like to be included on the certificate?");
+            chai.expect($(".govuk-checkboxes__item").length).to.be.greaterThan(0);
+            chai.expect($(".govuk-checkboxes__item:nth-of-type(4)").find("label").text().trim()).to.equal("Liquidators");
         });
     });
 
     describe("certificate options patch", () => {
         it("redirects the user to the delivery-details page", async () => {
-            const certificateDetails = {} as CertificateItem;
-
             getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
-            getCompanyProfileStub = sandbox.stub(apiClient, "getCompanyProfile")
-                .returns(Promise.resolve(companyProfile));
             patchCertificateItemStub = sandbox.stub(apiClient, "patchCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
 
@@ -95,12 +126,8 @@ describe("llp.certificate.options.controller.integration", () => {
         });
 
         it("redirects the user to the registered-office-options page", async () => {
-            const certificateDetails = {} as CertificateItem;
-
             getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
-            getCompanyProfileStub = sandbox.stub(apiClient, "getCompanyProfile")
-                .returns(Promise.resolve(companyProfile));
             patchCertificateItemStub = sandbox.stub(apiClient, "patchCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
 
@@ -117,12 +144,8 @@ describe("llp.certificate.options.controller.integration", () => {
         });
 
         it("redirects the user to the designated-member-options page", async () => {
-            const certificateDetails = {} as CertificateItem;
-
             getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
-            getCompanyProfileStub = sandbox.stub(apiClient, "getCompanyProfile")
-                .returns(Promise.resolve(companyProfile));
             patchCertificateItemStub = sandbox.stub(apiClient, "patchCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
 
@@ -139,12 +162,8 @@ describe("llp.certificate.options.controller.integration", () => {
         });
 
         it("redirects the user to the member-options page", async () => {
-            const certificateDetails = {} as CertificateItem;
-
             getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
-            getCompanyProfileStub = sandbox.stub(apiClient, "getCompanyProfile")
-                .returns(Promise.resolve(companyProfile));
             patchCertificateItemStub = sandbox.stub(apiClient, "patchCertificateItem")
                 .returns(Promise.resolve(certificateDetails));
 


### PR DESCRIPTION
- Bypasses calls to companyProfile in the options controllers for default and LLP company types.
- Instead, uses companyStatus off of the certificateItem

[BI-9890](https://companieshouse.atlassian.net/browse/BI-9890)