### PR TITLE
little change to exclude other links from stating opens opens in new tab

### DIFF
--- a/src/views/components/footer/template.njk
+++ b/src/views/components/footer/template.njk
@@ -36,7 +36,7 @@
           {% if params.meta.items %}
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}
-              {% if item === item.target %}
+              {% if item.target %}
                 <li class="govuk-footer__inline-list-item">
                   <a class="govuk-footer__link" href="{{ item.href }}" target="{{ item.target }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
                     {{ item.text }} <span class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Link opens in new tab") }}</span>


### PR DESCRIPTION
BI-9825 Direct users to GOV.UK contact page - Missing image delivery