### PR TITLE
Add extra line break to check details opts

### DIFF
--- a/src/controllers/certificates/check.details.controller.ts
+++ b/src/controllers/certificates/check.details.controller.ts
@@ -138,6 +138,7 @@ export const mapDirectorOptions = (directorOptions?: DirectorOrSecretaryDetails)
 
     const mappings: string[] = [];
     mappings.push("Including directors':");
+    mappings.push("");
 
     if (directorOptions.includeAddress) {
         mappings.push("Correspondence address");
@@ -180,6 +181,7 @@ export const mapSecretaryOptions = (secretaryOptions?: DirectorOrSecretaryDetail
 
     const secretaryMappings: string[] = [];
     secretaryMappings.push("Including secretaries':");
+    secretaryMappings.push("");
 
     if (secretaryOptions.includeAddress) {
         secretaryMappings.push("Correspondence address");

--- a/src/controllers/certificates/llp-certificates/check.details.controller.ts
+++ b/src/controllers/certificates/llp-certificates/check.details.controller.ts
@@ -150,6 +150,7 @@ export const mapDesignatedMembersOptions = (designatedMembersOptions?: Designate
 
     const designatedMembersMappings: string[] = [];
     designatedMembersMappings.push("Including designated members':");
+    designatedMembersMappings.push("");
 
     if (designatedMembersOptions.includeAddress) {
         designatedMembersMappings.push("Correspondence address");
@@ -186,6 +187,7 @@ export const mapMembersOptions = (memberOptions?: MemberDetails): string => {
 
     const membersMappings: string[] = [];
     membersMappings.push("Including members':");
+    membersMappings.push("");
 
     if (memberOptions.includeAddress) {
         membersMappings.push("Correspondence address");

--- a/test/controller/certificates/check.details.controller.unit.test.ts
+++ b/test/controller/certificates/check.details.controller.unit.test.ts
@@ -140,7 +140,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapDirectorOptions(directorOptions))
-                .to.equal("Including directors&#39;:<br>Correspondence address<br>Occupation<br>Date of birth (month and year)<br>Appointment date<br>Nationality<br>Country of residence<br>");
+                .to.equal("Including directors&#39;:<br><br>Correspondence address<br>Occupation<br>Date of birth (month and year)<br>Appointment date<br>Nationality<br>Country of residence<br>");
         });
 
         it("maps correctly when only one additional option selected", () => {
@@ -150,7 +150,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapDirectorOptions(directorOptions))
-                .to.equal("Including directors&#39;:<br>Nationality<br>");
+                .to.equal("Including directors&#39;:<br><br>Nationality<br>");
         });
 
         it("maps correctly when only basic information present", () => {
@@ -184,7 +184,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapSecretaryOptions(secretaryOptions))
-                .to.equal("Including secretaries&#39;:<br>Correspondence address<br>Appointment date<br>");
+                .to.equal("Including secretaries&#39;:<br><br>Correspondence address<br>Appointment date<br>");
         });
 
         it("maps correctly when only one additional option selected", () => {
@@ -194,7 +194,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapSecretaryOptions(secretaryOptions))
-                .to.equal("Including secretaries&#39;:<br>Appointment date<br>");
+                .to.equal("Including secretaries&#39;:<br><br>Appointment date<br>");
         });
 
         it("maps correctly when only basic information present", () => {

--- a/test/controller/certificates/llp-certificates/check.details.controller.unit.test.ts
+++ b/test/controller/certificates/llp-certificates/check.details.controller.unit.test.ts
@@ -65,7 +65,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapDesignatedMembersOptions(designatedMemberOptions))
-                .to.equal("Including designated members&#39;:<br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
+                .to.equal("Including designated members&#39;:<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
         });
 
         it("maps correctly when only one additional option selected", () => {
@@ -75,7 +75,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapDesignatedMembersOptions(designatedMemberOptions))
-                .to.equal("Including designated members&#39;:<br>Country of residence<br>");
+                .to.equal("Including designated members&#39;:<br><br>Country of residence<br>");
         });
 
         it("maps correctly when only basic information present", () => {
@@ -110,7 +110,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapMembersOptions(memberOptions))
-                .to.equal("Including members&#39;:<br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
+                .to.equal("Including members&#39;:<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
         });
 
         it("maps correctly when only one additional option selected", () => {
@@ -120,7 +120,7 @@ describe("certificate.check.details.controller.unit", () => {
             };
 
             chai.expect(mapMembersOptions(memberOptions))
-                .to.equal("Including members&#39;:<br>Country of residence<br>");
+                .to.equal("Including members&#39;:<br><br>Country of residence<br>");
         });
 
         it("maps correctly when only basic information present", () => {


### PR DESCRIPTION
* Add extra line break where directors, secretaries or members options
  have been chosen to make text consistent with confirmation page.