### PR TITLE
Fix bug where includeBasicInformation was not checked

### DIFF
--- a/src/controllers/certificates/director.options.controller.ts
+++ b/src/controllers/certificates/director.options.controller.ts
@@ -55,7 +55,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const userId = getUserId(req.session);
         const patchResponse = await patchCertificateItem(accessToken, req.params.certificateId, certificateItem);
         logger.info(`Patched certificate item with director options, id=${req.params.certificateId}, user_id=${userId}, company_number=${patchResponse.companyNumber}, certificate_options=${JSON.stringify(certificateItem)}`);
-        if (patchResponse.itemOptions.secretaryDetails) {
+        if (patchResponse.itemOptions.secretaryDetails?.includeBasicInformation) {
             return res.redirect("secretary-options");
         } else {
             return res.redirect("delivery-details");

--- a/src/controllers/certificates/llp-certificates/designated-members.options.controller.ts
+++ b/src/controllers/certificates/llp-certificates/designated-members.options.controller.ts
@@ -49,7 +49,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         const userId = getUserId(req.session);
         const patchResponse = await patchCertificateItem(accessToken, req.params.certificateId, certificateItem);
         logger.info(`Patched certificate item with designated member options, id=${req.params.certificateId}, user_id=${userId}, company_number=${patchResponse.companyNumber}, certificate_options=${JSON.stringify(certificateItem)}`);
-        if (patchResponse.itemOptions.memberDetails) {
+        if (patchResponse.itemOptions.memberDetails?.includeBasicInformation) {
             return res.redirect("members-options");
         } else {
             return res.redirect("delivery-details");

--- a/src/controllers/certificates/llp-certificates/registered.office.options.controller.ts
+++ b/src/controllers/certificates/llp-certificates/registered.office.options.controller.ts
@@ -69,9 +69,9 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
         req.session?.setExtraData("certificates-orders-web-ch-gov-uk", {
             isFullPage: isFullPage
         } as CertificateSessionData);
-        if (patchResponse.itemOptions.designatedMemberDetails) {
+        if (patchResponse.itemOptions.designatedMemberDetails?.includeBasicInformation) {
             return res.redirect("designated-members-options");
-        } else if (patchResponse.itemOptions.memberDetails) {
+        } else if (patchResponse.itemOptions.memberDetails?.includeBasicInformation) {
             return res.redirect("members-options");
         } else {
             return res.redirect("delivery-details");

--- a/src/controllers/certificates/registered.office.options.controller.ts
+++ b/src/controllers/certificates/registered.office.options.controller.ts
@@ -72,9 +72,9 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
         req.session?.setExtraData("certificates-orders-web-ch-gov-uk", {
             isFullPage: isFullPage
         } as CertificateSessionData);
-        if (patchResponse.itemOptions.directorDetails) {
+        if (patchResponse.itemOptions.directorDetails?.includeBasicInformation) {
             return res.redirect("director-options");
-        } else if (patchResponse.itemOptions.secretaryDetails) {
+        } else if (patchResponse.itemOptions.secretaryDetails?.includeBasicInformation) {
             return res.redirect("secretary-options");
         } else {
             return res.redirect("delivery-details");


### PR DESCRIPTION
* ROA, directors and designated members controllers were not checking includeBasicInformation on the patched item's
* item options when determining which page to redirect to.

* Tested locally, works fine.