### PR TITLE
BI-10811 Rework options page redirects

### DIFF
--- a/src/controllers/certificates/options/AbstractOptionsMapper.ts
+++ b/src/controllers/certificates/options/AbstractOptionsMapper.ts
@@ -1,24 +1,14 @@
 import {
     CertificateItem,
-    CertificateItemPatchRequest, ItemOptionsRequest
+    CertificateItemPatchRequest,
+    ItemOptionsRequest
 } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { OptionsViewModel } from "./OptionsViewModel";
-import { SelectedOptions } from "./OptionsService";
+import { ResourceState, SelectedOptions } from "./OptionsService";
 import { OptionsPageRedirect } from "./OptionsPageRedirect";
+import { RedirectStateMachine } from "./RedirectStateMachine";
 
-export abstract class AbstractOptionsMapper {
-    private optionRedirects: Map<string, OptionsPageRedirect>
-    private defaultRedirect: OptionsPageRedirect;
-
-    constructor (defaultRedirect: OptionsPageRedirect) {
-        this.optionRedirects = new Map<string, OptionsPageRedirect>();
-        this.defaultRedirect = defaultRedirect;
-    }
-
-    addRedirectForOption (option: string, redirect: OptionsPageRedirect) {
-        this.optionRedirects.set(option, redirect);
-    }
-
+export abstract class AbstractOptionsMapper<T extends RedirectStateMachine> {
     abstract mapItemToOptions (item: CertificateItem): OptionsViewModel;
 
     mapOptionsToUpdate (companyStatus: string, selectedOptions: SelectedOptions): CertificateItemPatchRequest {
@@ -37,36 +27,26 @@ export abstract class AbstractOptionsMapper {
 
     abstract filterItemOptions (itemOptionsAccum: ItemOptionsRequest, option: string): ItemOptionsRequest;
 
-    mapOptionsToRedirect (selectedOptions: SelectedOptions): OptionsPageRedirect {
+    getRedirect (selectedOptions: SelectedOptions, resourceState: ResourceState): OptionsPageRedirect {
         const options = this.mapSelectedOptionsToArray(selectedOptions);
-        if (options.length > 0) {
-            options.sort(this.optionPriorityComparator.bind(this));
-            return this.optionRedirects.get(options[0]) || this.defaultRedirect;
-        } else {
-            return this.defaultRedirect;
+        const stateMachine = this.getStateMachine(resourceState);
+        for (const option of options) {
+            this.handleOption(option, stateMachine);
         }
+        return new OptionsPageRedirect(stateMachine.getRedirect());
     }
 
-    private mapSelectedOptionsToArray (selectedOptions: SelectedOptions): string[] {
+    abstract getStateMachine (resourceState: ResourceState): T;
+
+    abstract handleOption (option: string, redirectStateMachine: T): void;
+
+    mapSelectedOptionsToArray (selectedOptions: SelectedOptions): string[] {
         if (selectedOptions === undefined) {
             return [];
         } else if (typeof selectedOptions === "string") {
             return [selectedOptions];
         } else {
             return selectedOptions;
-        }
-    }
-
-    private optionPriorityComparator (a: string, b: string): number {
-        if (this.optionRedirects.has(a) && this.optionRedirects.has(b)) {
-            return ((this.optionRedirects.get(a) || {}).priority || 0) -
-                ((this.optionRedirects.get(b) || {}).priority || 0);
-        } else if (this.optionRedirects.has(a)) {
-            return -1;
-        } else if (this.optionRedirects.has(b)) {
-            return 1;
-        } else {
-            return 0;
         }
     }
 }

--- a/src/controllers/certificates/options/LLPOptionsMapper.ts
+++ b/src/controllers/certificates/options/LLPOptionsMapper.ts
@@ -9,8 +9,10 @@ import { optionFilter } from "../OptionFilter";
 import { LLP_ROOT_CERTIFICATE, replaceCompanyNumber } from "../../../model/page.urls";
 import { AbstractOptionsMapper } from "./AbstractOptionsMapper";
 import { OptionSelection } from "./OptionSelection";
+import { LLPRedirectStateMachine } from "./LLPRedirectStateMachine";
+import { ResourceState } from "./OptionsService";
 
-export class LLPOptionsMapper extends AbstractOptionsMapper {
+export class LLPOptionsMapper extends AbstractOptionsMapper<LLPRedirectStateMachine> {
     mapItemToOptions (item: CertificateItem): OptionsViewModel {
         return new OptionsViewModel(LLP_CERTIFICATE_OPTIONS, {
             companyNumber: item.companyNumber,
@@ -63,7 +65,7 @@ export class LLPOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         case OptionSelection.REGISTERED_OFFICE_ADDRESS: {
-            itemOptionsAccum.registeredOfficeAddressDetails = {};
+            itemOptionsAccum.registeredOfficeAddressDetails = { includeAddressRecordsType: "current" };
             break;
         }
         case OptionSelection.DESIGNATED_MEMBERS: {
@@ -86,5 +88,19 @@ export class LLPOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         return itemOptionsAccum;
+    }
+
+    handleOption (option: string, redirectStateMachine: LLPRedirectStateMachine): void {
+        if (option === OptionSelection.REGISTERED_OFFICE_ADDRESS) {
+            redirectStateMachine.redirectAddressDetails();
+        } else if (option === OptionSelection.DESIGNATED_MEMBERS) {
+            redirectStateMachine.redirectDesignatedMemberDetails();
+        } else if (option === OptionSelection.MEMBERS) {
+            redirectStateMachine.redirectMemberDetails();
+        }
+    }
+
+    getStateMachine (resourceState: ResourceState): LLPRedirectStateMachine {
+        return new LLPRedirectStateMachine(resourceState);
     }
 }

--- a/src/controllers/certificates/options/LLPRedirectState.ts
+++ b/src/controllers/certificates/options/LLPRedirectState.ts
@@ -1,0 +1,91 @@
+import { RedirectState } from "./RedirectState";
+import { LLPRedirectStateMachine } from "./LLPRedirectStateMachine";
+
+export interface LLPRedirectState extends RedirectState {
+    redirectDesignatedMemberDetails(): void;
+    redirectMemberDetails(): void;
+}
+
+export class NoOptionsPresentState implements LLPRedirectState {
+    private stateMachine: LLPRedirectStateMachine;
+    readonly redirect = "delivery-details";
+
+    constructor (stateMachine: LLPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDesignatedMemberDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.designatedMemberDetailsPresentState;
+    }
+
+    redirectMemberDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.memberDetailsPresentState;
+    }
+}
+
+export class RegisteredOfficePresentState implements LLPRedirectState {
+    private stateMachine: LLPRedirectStateMachine;
+    readonly redirect = "registered-office-options";
+
+    constructor (stateMachine: LLPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        // do nothing
+    }
+
+    redirectDesignatedMemberDetails (): void {
+        // do nothing
+    }
+
+    redirectMemberDetails (): void {
+        // do nothing
+    }
+}
+
+export class DesignatedMemberDetailsPresentState implements LLPRedirectState {
+    private stateMachine: LLPRedirectStateMachine;
+    readonly redirect = "designated-members-options";
+
+    constructor (stateMachine: LLPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDesignatedMemberDetails (): void {
+        // do nothing
+    }
+
+    redirectMemberDetails (): void {
+        // do nothing
+    }
+}
+
+export class MemberDetailsPresentState implements LLPRedirectState {
+    private stateMachine: LLPRedirectStateMachine;
+    readonly redirect = "members-options";
+
+    constructor (stateMachine: LLPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDesignatedMemberDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.designatedMemberDetailsPresentState;
+    }
+
+    redirectMemberDetails (): void {
+        // do nothing
+    }
+}

--- a/src/controllers/certificates/options/LLPRedirectStateMachine.ts
+++ b/src/controllers/certificates/options/LLPRedirectStateMachine.ts
@@ -1,0 +1,46 @@
+import { ResourceState } from "./OptionsService";
+import { RedirectStateMachine } from "./RedirectStateMachine";
+import {
+    DesignatedMemberDetailsPresentState,
+    LLPRedirectState, MemberDetailsPresentState, NoOptionsPresentState,
+    RegisteredOfficePresentState
+} from "./LLPRedirectState";
+
+export class LLPRedirectStateMachine implements RedirectStateMachine {
+    readonly addressPresentState = new RegisteredOfficePresentState(this);
+    readonly designatedMemberDetailsPresentState = new DesignatedMemberDetailsPresentState(this);
+    readonly memberDetailsPresentState = new MemberDetailsPresentState(this);
+    readonly noOptionsPresentState = new NoOptionsPresentState(this);
+
+    private _currentState: LLPRedirectState;
+    private readonly _resourceState: ResourceState;
+
+    constructor (resourceState: ResourceState) {
+        this._currentState = this.noOptionsPresentState;
+        this._resourceState = resourceState;
+    }
+
+    redirectAddressDetails (): void {
+        this._currentState.redirectAddressDetails();
+    }
+
+    redirectDesignatedMemberDetails (): void {
+        this._currentState.redirectDesignatedMemberDetails();
+    }
+
+    redirectMemberDetails (): void {
+        this._currentState.redirectMemberDetails();
+    }
+
+    getRedirect (): string {
+        return this._currentState.redirect;
+    }
+
+    set currentState (currentState: LLPRedirectState) {
+        this._currentState = currentState;
+    }
+
+    get resourceState (): ResourceState {
+        return this._resourceState;
+    }
+}

--- a/src/controllers/certificates/options/LPOptionsMapper.ts
+++ b/src/controllers/certificates/options/LPOptionsMapper.ts
@@ -7,8 +7,10 @@ import { LP_CERTIFICATE_OPTIONS } from "../../../model/template.paths";
 import { AbstractOptionsMapper } from "./AbstractOptionsMapper";
 import { LP_ROOT_CERTIFICATE, replaceCompanyNumber } from "../../../model/page.urls";
 import { OptionSelection } from "./OptionSelection";
+import { LPRedirectStateMachine } from "./LPRedirectStateMachine";
+import { ResourceState } from "./OptionsService";
 
-export class LPOptionsMapper extends AbstractOptionsMapper {
+export class LPOptionsMapper extends AbstractOptionsMapper<LPRedirectStateMachine> {
     mapItemToOptions (item: CertificateItem): OptionsViewModel {
         return new OptionsViewModel(LP_CERTIFICATE_OPTIONS, {
             companyNumber: item.companyNumber,
@@ -42,7 +44,7 @@ export class LPOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         case OptionSelection.PRINCIPAL_PLACE_OF_BUSINESS: {
-            itemOptionsAccum.principalPlaceOfBusinessDetails = {};
+            itemOptionsAccum.principalPlaceOfBusinessDetails = { includeAddressRecordsType: "current" };
             break;
         }
         case OptionSelection.GENERAL_PARTNERS: {
@@ -61,5 +63,15 @@ export class LPOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         return itemOptionsAccum;
+    }
+
+    handleOption (option: string, redirectStateMachine: LPRedirectStateMachine): void {
+        if (option === OptionSelection.PRINCIPAL_PLACE_OF_BUSINESS) {
+            redirectStateMachine.redirectAddressDetails();
+        }
+    }
+
+    getStateMachine (resourceState: ResourceState): LPRedirectStateMachine {
+        return new LPRedirectStateMachine(resourceState);
     }
 }

--- a/src/controllers/certificates/options/LPRedirectState.ts
+++ b/src/controllers/certificates/options/LPRedirectState.ts
@@ -1,0 +1,31 @@
+import { RedirectState } from "./RedirectState";
+import { LPRedirectStateMachine } from "./LPRedirectStateMachine";
+
+export interface LPRedirectState extends RedirectState {
+}
+
+export class NoOptionsPresentState implements LPRedirectState {
+    private stateMachine: LPRedirectStateMachine;
+    readonly redirect = "delivery-details";
+
+    constructor (stateMachine: LPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+}
+
+export class PrincipalPlaceOfBusinessPresentState implements LPRedirectState {
+    private stateMachine: LPRedirectStateMachine;
+    readonly redirect = "principal-place-of-business-options";
+
+    constructor (stateMachine: LPRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        // do nothing
+    }
+}

--- a/src/controllers/certificates/options/LPRedirectStateMachine.ts
+++ b/src/controllers/certificates/options/LPRedirectStateMachine.ts
@@ -1,0 +1,36 @@
+import { ResourceState } from "./OptionsService";
+import { RedirectStateMachine } from "./RedirectStateMachine";
+import {
+    LPRedirectState,
+    NoOptionsPresentState,
+    PrincipalPlaceOfBusinessPresentState
+} from "./LPRedirectState";
+
+export class LPRedirectStateMachine implements RedirectStateMachine {
+    readonly addressPresentState = new PrincipalPlaceOfBusinessPresentState(this);
+    readonly noOptionsPresentState = new NoOptionsPresentState(this);
+
+    private _currentState: LPRedirectState;
+    private readonly _resourceState: ResourceState;
+
+    constructor (resourceState: ResourceState) {
+        this._currentState = this.noOptionsPresentState;
+        this._resourceState = resourceState;
+    }
+
+    redirectAddressDetails (): void {
+        this._currentState.redirectAddressDetails();
+    }
+
+    getRedirect (): string {
+        return this._currentState.redirect;
+    }
+
+    set currentState (currentState: LPRedirectState) {
+        this._currentState = currentState;
+    }
+
+    get resourceState (): ResourceState {
+        return this._resourceState;
+    }
+}

--- a/src/controllers/certificates/options/OptionsControllerConfiguration.ts
+++ b/src/controllers/certificates/options/OptionsControllerConfiguration.ts
@@ -3,18 +3,8 @@ import { OptionsService } from "./OptionsService";
 import { AbstractOptionsMapper } from "./AbstractOptionsMapper";
 import { CompanyType } from "../../../model/CompanyType";
 import { LLPOptionsMapper } from "./LLPOptionsMapper";
-import { OptionsPageRedirect } from "./OptionsPageRedirect";
-import { OptionSelection } from "./OptionSelection";
 import { LPOptionsMapper } from "./LPOptionsMapper";
 import { OtherCompanyOptionsMapper } from "./OtherCompanyOptionsMapper";
-
-const DELIVERY_DETAILS_REDIRECT = new OptionsPageRedirect("delivery-details");
-const REGISTERED_OFFICE_REDIRECT = new OptionsPageRedirect("registered-office-options", 1);
-const PRINCIPAL_PLACE_OF_BUSINESS_REDIRECT = new OptionsPageRedirect("principal-place-of-business-options", 1);
-const DIRECTORS_REDIRECT = new OptionsPageRedirect("director-options", 2);
-const DESIGNATED_MEMBER_REDIRECT = new OptionsPageRedirect("designated-members-options", 2);
-const SECRETARY_REDIRECT = new OptionsPageRedirect("secretary-options", 3);
-const MEMBER_REDIRECT = new OptionsPageRedirect("members-options", 3);
 
 export class OptionsControllerConfiguration {
     private static INSTANCE: OptionsController;
@@ -22,34 +12,12 @@ export class OptionsControllerConfiguration {
     public static optionsControllerInstance () {
         if (OptionsControllerConfiguration.INSTANCE == null) {
             OptionsControllerConfiguration.INSTANCE = new OptionsController(
-                new OptionsService(new Map<string, AbstractOptionsMapper>([
-                    [CompanyType.LIMITED_LIABILITY_PARTNERSHIP, OptionsControllerConfiguration.llpMapper()],
-                    [CompanyType.LIMITED_PARTNERSHIP, OptionsControllerConfiguration.lpMapper()]
-                ]), OptionsControllerConfiguration.otherCompanyTypeMapper())
+                new OptionsService(new Map<string, AbstractOptionsMapper<any>>([
+                    [CompanyType.LIMITED_LIABILITY_PARTNERSHIP, new LLPOptionsMapper()],
+                    [CompanyType.LIMITED_PARTNERSHIP, new LPOptionsMapper()]
+                ]), new OtherCompanyOptionsMapper())
             );
         }
         return OptionsControllerConfiguration.INSTANCE;
-    }
-
-    private static otherCompanyTypeMapper (): AbstractOptionsMapper {
-        const defaultMapper = new OtherCompanyOptionsMapper(DELIVERY_DETAILS_REDIRECT);
-        defaultMapper.addRedirectForOption(OptionSelection.REGISTERED_OFFICE_ADDRESS, REGISTERED_OFFICE_REDIRECT);
-        defaultMapper.addRedirectForOption(OptionSelection.DIRECTORS, DIRECTORS_REDIRECT);
-        defaultMapper.addRedirectForOption(OptionSelection.SECRETARIES, SECRETARY_REDIRECT);
-        return defaultMapper;
-    }
-
-    private static llpMapper (): AbstractOptionsMapper {
-        const llpMapper = new LLPOptionsMapper(DELIVERY_DETAILS_REDIRECT);
-        llpMapper.addRedirectForOption(OptionSelection.REGISTERED_OFFICE_ADDRESS, REGISTERED_OFFICE_REDIRECT);
-        llpMapper.addRedirectForOption(OptionSelection.DESIGNATED_MEMBERS, DESIGNATED_MEMBER_REDIRECT);
-        llpMapper.addRedirectForOption(OptionSelection.MEMBERS, MEMBER_REDIRECT);
-        return llpMapper;
-    }
-
-    private static lpMapper (): AbstractOptionsMapper {
-        const lpMapper = new LPOptionsMapper(DELIVERY_DETAILS_REDIRECT);
-        lpMapper.addRedirectForOption(OptionSelection.PRINCIPAL_PLACE_OF_BUSINESS, PRINCIPAL_PLACE_OF_BUSINESS_REDIRECT);
-        return lpMapper;
     }
 }

--- a/src/controllers/certificates/options/OptionsPageRedirect.ts
+++ b/src/controllers/certificates/options/OptionsPageRedirect.ts
@@ -1,17 +1,11 @@
 export class OptionsPageRedirect {
     private readonly _redirect: string;
-    private readonly _priority: number | undefined;
 
-    constructor (redirect: string, priority?: number) {
+    constructor (redirect: string) {
         this._redirect = redirect;
-        this._priority = priority;
     }
 
     get redirect (): string {
         return this._redirect;
-    }
-
-    get priority (): number | undefined {
-        return this._priority;
     }
 }

--- a/src/controllers/certificates/options/OptionsService.ts
+++ b/src/controllers/certificates/options/OptionsService.ts
@@ -1,15 +1,19 @@
 import { OptionsViewModel } from "./OptionsViewModel";
 import { getCertificateItem, patchCertificateItem } from "../../../client/api.client";
 import { AbstractOptionsMapper } from "./AbstractOptionsMapper";
+import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { OptionsPageRedirect } from "./OptionsPageRedirect";
 
 export type SelectedOptions = string | string[] | undefined;
+export type ResourceState = {
+    certificateItem: CertificateItem
+};
 
 export class OptionsService {
-    private readonly typeMappers: Map<string, AbstractOptionsMapper>;
-    private readonly defaultMapper: AbstractOptionsMapper;
+    private readonly typeMappers: Map<string, AbstractOptionsMapper<any>>;
+    private readonly defaultMapper: AbstractOptionsMapper<any>;
 
-    constructor (typeMappers: Map<string, AbstractOptionsMapper>, defaultMapper: AbstractOptionsMapper) {
+    constructor (typeMappers: Map<string, AbstractOptionsMapper<any>>, defaultMapper: AbstractOptionsMapper<any>) {
         this.typeMappers = typeMappers;
         this.defaultMapper = defaultMapper;
     }
@@ -24,7 +28,7 @@ export class OptionsService {
         const certificate = await getCertificateItem(token, id);
         const mapper = (this.typeMappers.get(certificate.itemOptions.companyType) || this.defaultMapper);
         const update = mapper.mapOptionsToUpdate(certificate.itemOptions.companyStatus, options);
-        await patchCertificateItem(token, id, update);
-        return mapper.mapOptionsToRedirect(options);
+        const result = await patchCertificateItem(token, id, update);
+        return mapper.getRedirect(options, { certificateItem: result });
     }
 }

--- a/src/controllers/certificates/options/OtherCompanyOptionsMapper.ts
+++ b/src/controllers/certificates/options/OtherCompanyOptionsMapper.ts
@@ -8,8 +8,10 @@ import { CompanyStatus } from "../model/CompanyStatus";
 import { AbstractOptionsMapper } from "./AbstractOptionsMapper";
 import { optionFilter } from "../OptionFilter";
 import { OptionSelection } from "./OptionSelection";
+import { ResourceState } from "./OptionsService";
+import { OtherCompanyRedirectStateMachine } from "./OtherCompanyRedirectStateMachine";
 
-export class OtherCompanyOptionsMapper extends AbstractOptionsMapper {
+export class OtherCompanyOptionsMapper extends AbstractOptionsMapper<OtherCompanyRedirectStateMachine> {
     mapItemToOptions (item: CertificateItem): OptionsViewModel {
         return new OptionsViewModel(CERTIFICATE_OPTIONS, {
             companyNumber: item.companyNumber,
@@ -62,7 +64,7 @@ export class OtherCompanyOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         case OptionSelection.REGISTERED_OFFICE_ADDRESS: {
-            itemOptionsAccum.registeredOfficeAddressDetails = {};
+            itemOptionsAccum.registeredOfficeAddressDetails = { includeAddressRecordsType: "current" };
             break;
         }
         case OptionSelection.DIRECTORS: {
@@ -89,5 +91,19 @@ export class OtherCompanyOptionsMapper extends AbstractOptionsMapper {
             break;
         }
         return itemOptionsAccum;
+    }
+
+    handleOption (option: string, redirectStateMachine: OtherCompanyRedirectStateMachine) {
+        if (option === OptionSelection.REGISTERED_OFFICE_ADDRESS) {
+            redirectStateMachine.redirectAddressDetails();
+        } else if (option === OptionSelection.DIRECTORS) {
+            redirectStateMachine.redirectDirectorDetails();
+        } else if (option === OptionSelection.SECRETARIES) {
+            redirectStateMachine.redirectSecretaryDetails();
+        }
+    }
+
+    getStateMachine (resourceState: ResourceState): OtherCompanyRedirectStateMachine {
+        return new OtherCompanyRedirectStateMachine(resourceState);
     }
 }

--- a/src/controllers/certificates/options/OtherCompanyRedirectState.ts
+++ b/src/controllers/certificates/options/OtherCompanyRedirectState.ts
@@ -1,0 +1,91 @@
+import { RedirectState } from "./RedirectState";
+import { OtherCompanyRedirectStateMachine } from "./OtherCompanyRedirectStateMachine";
+
+export interface OtherCompanyRedirectState extends RedirectState {
+    redirectDirectorDetails(): void;
+    redirectSecretaryDetails(): void;
+}
+
+export class NoOptionsPresentState implements OtherCompanyRedirectState {
+    private stateMachine: OtherCompanyRedirectStateMachine;
+    readonly redirect = "delivery-details";
+
+    constructor (stateMachine: OtherCompanyRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDirectorDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.directorDetailsPresentState;
+    }
+
+    redirectSecretaryDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.secretaryDetailsPresentState;
+    }
+}
+
+export class RegisteredOfficePresentState implements OtherCompanyRedirectState {
+    private stateMachine: OtherCompanyRedirectStateMachine;
+    readonly redirect = "registered-office-options";
+
+    constructor (stateMachine: OtherCompanyRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        // do nothing
+    }
+
+    redirectDirectorDetails (): void {
+        // do nothing
+    }
+
+    redirectSecretaryDetails (): void {
+        // do nothing
+    }
+}
+
+export class DirectorDetailsPresentState implements OtherCompanyRedirectState {
+    private stateMachine: OtherCompanyRedirectStateMachine;
+    readonly redirect = "director-options";
+
+    constructor (stateMachine: OtherCompanyRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDirectorDetails (): void {
+        // do nothing
+    }
+
+    redirectSecretaryDetails (): void {
+        // do nothing
+    }
+}
+
+export class SecretaryDetailsPresentState implements OtherCompanyRedirectState {
+    private stateMachine: OtherCompanyRedirectStateMachine;
+    readonly redirect = "secretary-options";
+
+    constructor (stateMachine: OtherCompanyRedirectStateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    redirectAddressDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.addressPresentState;
+    }
+
+    redirectDirectorDetails (): void {
+        this.stateMachine.currentState = this.stateMachine.directorDetailsPresentState;
+    }
+
+    redirectSecretaryDetails (): void {
+        // do nothing
+    }
+}

--- a/src/controllers/certificates/options/OtherCompanyRedirectStateMachine.ts
+++ b/src/controllers/certificates/options/OtherCompanyRedirectStateMachine.ts
@@ -1,0 +1,47 @@
+import {
+    NoOptionsPresentState,
+    DirectorDetailsPresentState,
+    OtherCompanyRedirectState,
+    RegisteredOfficePresentState, SecretaryDetailsPresentState
+} from "./OtherCompanyRedirectState";
+import { ResourceState } from "./OptionsService";
+import { RedirectStateMachine } from "./RedirectStateMachine";
+
+export class OtherCompanyRedirectStateMachine implements RedirectStateMachine {
+    readonly addressPresentState = new RegisteredOfficePresentState(this);
+    readonly directorDetailsPresentState = new DirectorDetailsPresentState(this);
+    readonly secretaryDetailsPresentState = new SecretaryDetailsPresentState(this);
+    readonly noOptionsPresentState = new NoOptionsPresentState(this);
+
+    private _currentState: OtherCompanyRedirectState;
+    private readonly _resourceState: ResourceState;
+
+    constructor (resourceState: ResourceState) {
+        this._currentState = this.noOptionsPresentState;
+        this._resourceState = resourceState;
+    }
+
+    redirectAddressDetails (): void {
+        this._currentState.redirectAddressDetails();
+    }
+
+    redirectDirectorDetails (): void {
+        this._currentState.redirectDirectorDetails();
+    }
+
+    redirectSecretaryDetails (): void {
+        this._currentState.redirectSecretaryDetails();
+    }
+
+    getRedirect (): string {
+        return this._currentState.redirect;
+    }
+
+    set currentState (currentState: OtherCompanyRedirectState) {
+        this._currentState = currentState;
+    }
+
+    get resourceState (): ResourceState {
+        return this._resourceState;
+    }
+}

--- a/src/controllers/certificates/options/RedirectState.ts
+++ b/src/controllers/certificates/options/RedirectState.ts
@@ -1,0 +1,4 @@
+export interface RedirectState {
+    redirect: string;
+    redirectAddressDetails(): void
+}

--- a/src/controllers/certificates/options/RedirectStateMachine.ts
+++ b/src/controllers/certificates/options/RedirectStateMachine.ts
@@ -1,0 +1,3 @@
+export interface RedirectStateMachine {
+    getRedirect(): string;
+}

--- a/test/controller/certificates/options/LPOptionsMapper.unit.test.ts
+++ b/test/controller/certificates/options/LPOptionsMapper.unit.test.ts
@@ -12,7 +12,7 @@ import { CompanyStatus } from "../../../../src/controllers/certificates/model/Co
 const chai = require("chai");
 
 describe("LPOptionMapper", () => {
-    const mapper = new LPOptionsMapper(new OptionsPageRedirect("default"));
+    const mapper = new LPOptionsMapper();
     describe("Map item to options", () => {
         it("Creates an OptionsViewModel instance for an active company", () => {
             // given
@@ -85,7 +85,7 @@ describe("LPOptionMapper", () => {
             const actual = mapper.filterItemOptions(itemOptions, option);
 
             // then
-            chai.expect(actual.principalPlaceOfBusinessDetails?.includeAddressRecordsType).to.be.undefined;
+            chai.expect(actual.principalPlaceOfBusinessDetails?.includeAddressRecordsType).to.equal("current");
             chai.expect(actual.principalPlaceOfBusinessDetails?.includeDates).to.be.undefined;
         });
 
@@ -123,6 +123,35 @@ describe("LPOptionMapper", () => {
 
             // then
             chai.expect(actual).to.deep.equal({});
+        });
+    });
+    describe("Map selected options to a redirect model instance", () => {
+        it("Returns principal place of business details redirect if selected", () => {
+            // given
+            const options = [
+                OptionSelection.PRINCIPAL_PLACE_OF_BUSINESS,
+                OptionSelection.LIQUIDATORS_DETAILS,
+                OptionSelection.GENERAL_PARTNERS,
+                OptionSelection.LIMITED_PARTNERS,
+                OptionSelection.GENERAL_NATURE_OF_BUSINESS
+            ];
+
+            // when
+            const actual = mapper.getRedirect(options, { certificateItem: {} as CertificateItem });
+
+            // then
+            chai.expect(actual).to.deep.equal(new OptionsPageRedirect("principal-place-of-business-options"));
+        });
+
+        it("Returns delivery details redirect if no options selected", () => {
+            // given
+            const options = [];
+
+            // when
+            const actual = mapper.getRedirect(options, { certificateItem: {} as CertificateItem });
+
+            // then
+            chai.expect(actual).to.deep.equal(new OptionsPageRedirect("delivery-details"));
         });
     });
 });

--- a/test/controller/certificates/options/OptionsService.unit.test.ts
+++ b/test/controller/certificates/options/OptionsService.unit.test.ts
@@ -26,7 +26,7 @@ describe("OptionsService", () => {
     beforeEach(() => {
         mapperHandled = sandbox.createStubInstance(OtherCompanyOptionsMapper);
         mapperUnhandled = sandbox.createStubInstance(OtherCompanyOptionsMapper);
-        service = new OptionsService(new Map<string, AbstractOptionsMapper>([["handled", mapperHandled as any]]), mapperUnhandled as any);
+        service = new OptionsService(new Map<string, AbstractOptionsMapper<any>>([["handled", mapperHandled as any]]), mapperUnhandled as any);
     });
 
     afterEach(() => {
@@ -69,7 +69,7 @@ describe("OptionsService", () => {
     it("Updates a certificate item for a handled company type using provided options", async () => {
         // given
         mapperHandled.mapOptionsToUpdate.returns({} as CertificateItemPatchRequest);
-        mapperHandled.mapOptionsToRedirect.returns(new OptionsPageRedirect("redirect", 1));
+        mapperHandled.getRedirect.returns(new OptionsPageRedirect("redirect"));
         sandbox.stub(apiClient, "getCertificateItem").returns(Promise.resolve({
             itemOptions: {
                 companyType: "handled"
@@ -81,13 +81,13 @@ describe("OptionsService", () => {
         const actual = await service.updateCertificate("F00DFACE", "CAFE", ["option"]);
 
         // then
-        chai.expect(actual).to.deep.equal(new OptionsPageRedirect("redirect", 1));
+        chai.expect(actual).to.deep.equal(new OptionsPageRedirect("redirect"));
     });
 
     it("Updates a certificate item for an unhandled company type using provided options", async () => {
         // given
         mapperUnhandled.mapOptionsToUpdate.returns({} as CertificateItemPatchRequest);
-        mapperUnhandled.mapOptionsToRedirect.returns(new OptionsPageRedirect("redirect", 1));
+        mapperUnhandled.getRedirect.returns(new OptionsPageRedirect("redirect"));
         sandbox.stub(apiClient, "getCertificateItem").returns(Promise.resolve({
             itemOptions: {
                 companyType: "unhandled"
@@ -99,6 +99,6 @@ describe("OptionsService", () => {
         const actual = await service.updateCertificate("F00DFACE", "CAFE", ["option"]);
 
         // then
-        chai.expect(actual).to.deep.equal(new OptionsPageRedirect("redirect", 1));
+        chai.expect(actual).to.deep.equal(new OptionsPageRedirect("redirect"));
     });
 });


### PR DESCRIPTION
* Use template method/state pattern to determine a redirect on the
  options page for LLP/LP/other company types for the provided options.
* Set ROA/PPB include_address_records_type to current by default if
  selected on options page.

Resolves:
[BI-10811](https://companieshouse.atlassian.net/browse/BI-10811)