### PR TITLE
display previously selected delivery option value

### DIFF
--- a/src/controllers/certificates/delivery.options.controller.ts
+++ b/src/controllers/certificates/delivery.options.controller.ts
@@ -28,6 +28,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         logger.info(`Get certificate item, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
         return res.render(DELIVERY_OPTIONS, {
             DISPATCH_DAYS,
+            deliveryOption: certificateItem.itemOptions.deliveryTimescale,
             templateName: DELIVERY_DETAILS,
             pageTitleText: PAGE_TITLE,
             SERVICE_URL: setServiceUrl(certificateItem),

--- a/src/views/delivery-options.html
+++ b/src/views/delivery-options.html
@@ -54,7 +54,8 @@
             },
             attributes: {
               "data-event-id" : "express-delivery"
-            }
+            },
+            checked: true if deliveryOption == 'same-day'
           },
           {
             value: "standard",
@@ -64,7 +65,8 @@
             },
             attributes: {
               "data-event-id" : "standard-delivery"
-            }
+            },
+            checked: true if deliveryOption == 'standard'
           }
         ]
         }) }}

--- a/test/controller/certificates/delivery.details.controller.integration.test.ts
+++ b/test/controller/certificates/delivery.details.controller.integration.test.ts
@@ -6,7 +6,7 @@ import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/orde
 import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import * as apiClient from "../../../src/client/api.client";
-import { CERTIFICATE_DELIVERY_DETAILS, CERTIFICATE_DELIVERY_OPTIONS, replaceCertificateId } from "../../../src/model/page.urls";
+import { CERTIFICATE_DELIVERY_DETAILS, replaceCertificateId } from "../../../src/model/page.urls";
 import * as errorMessages from "../../../src/model/error.messages";
 import { SIGNED_IN_COOKIE, signedInSession } from "../../__mocks__/redis.mocks";
 
@@ -27,7 +27,6 @@ const POSTCODE: string = "CX14 1BX";
 const COUNTY: string = "county";
 const CERTIFICATE_ID = "CHS00000000000000001";
 const DELIVERY_DETAILS_URL = replaceCertificateId(CERTIFICATE_DELIVERY_DETAILS, CERTIFICATE_ID);
-const DELIVERY_OPTIONS_URL = replaceCertificateId(CERTIFICATE_DELIVERY_OPTIONS, CERTIFICATE_ID);
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
@@ -224,7 +223,7 @@ describe("certificate.delivery.details.controller", () => {
     });
 
     describe("delivery details back button", () => {
-        it("back button takes the user to the certificate options page if they have not selected any options", async () => {
+        it("back button takes the user to the delivery options page", async () => {
             const basketDetails = {} as Basket;
             const certificateItem = {} as CertificateItem;
 
@@ -233,142 +232,13 @@ describe("certificate.delivery.details.controller", () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
 
             const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
+                .get(DELIVERY_DETAILS_URL)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
 
             const $ = cheerio.load(resp.text);
 
             chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("certificate-options");
-        });
-
-        it("back button takes the user to the registered office options page if they selected only the registered office option", async () => {
-            const basketDetails = {} as Basket;
-            const certificateItem = {
-                itemOptions: {
-                    registeredOfficeAddressDetails: {
-                        includeAddressRecordsType: "current"
-                    }
-                }
-            } as CertificateItem;
-
-            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
-                .returns(Promise.resolve(certificateItem));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
-
-            const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
-                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
-
-            const $ = cheerio.load(resp.text);
-
-            chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("registered-office-options");
-        });
-
-        it("back button takes the user to the director options page if they selected only the director options", async () => {
-            const basketDetails = {} as Basket;
-            const certificateItem = {
-                itemOptions: {
-                    directorDetails: {
-                        includeBasicInformation: true
-                    }
-                }
-            } as CertificateItem;
-
-            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
-                .returns(Promise.resolve(certificateItem));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
-
-            const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
-                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
-
-            const $ = cheerio.load(resp.text);
-
-            chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("director-options");
-        });
-
-        it("back button takes the user to the secretary options page if they selected only the secretary options", async () => {
-            const basketDetails = {} as Basket;
-            const certificateItem = {
-                itemOptions: {
-                    secretaryDetails: {
-                        includeBasicInformation: true
-                    }
-                }
-            } as CertificateItem;
-
-            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
-                .returns(Promise.resolve(certificateItem));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
-
-            const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
-                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
-
-            const $ = cheerio.load(resp.text);
-
-            chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("secretary-options");
-        });
-
-        it("back button takes the user to the director options page if they selected both the director options and registered office options", async () => {
-            const basketDetails = {} as Basket;
-            const certificateItem = {
-                itemOptions: {
-                    registeredOfficeAddressDetails: {
-                        includeAddressRecordsType: "current"
-                    },
-                    directorDetails: {
-                        includeBasicInformation: true
-                    }
-                }
-            } as CertificateItem;
-
-            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
-                .returns(Promise.resolve(certificateItem));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
-
-            const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
-                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
-
-            const $ = cheerio.load(resp.text);
-
-            chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("director-options");
-        });
-
-        it("back button takes the user to the secretary options page if they selected the director, secretary and registered office options", async () => {
-            const basketDetails = {} as Basket;
-            const certificateItem = {
-                itemOptions: {
-                    registeredOfficeAddressDetails: {
-                        includeAddressRecordsType: "current"
-                    },
-                    directorDetails: {
-                        includeBasicInformation: true
-                    },
-                    secretaryDetails: {
-                        includeBasicInformation: true
-                    }
-                }
-            } as CertificateItem;
-
-            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
-                .returns(Promise.resolve(certificateItem));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
-
-            const resp = await chai.request(testApp)
-                .get(DELIVERY_OPTIONS_URL)
-                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
-
-            const $ = cheerio.load(resp.text);
-
-            chai.expect(resp.status).to.equal(200);
-            chai.expect($(".govuk-back-link").attr("href")).to.include("secretary-options");
+            chai.expect($(".govuk-back-link").attr("href")).to.include("delivery-options");
         });
     });
 });

--- a/test/controller/certificates/delivery.options.controller.integration.test.ts
+++ b/test/controller/certificates/delivery.options.controller.integration.test.ts
@@ -94,4 +94,159 @@ describe("delivery.options.integration.test", () => {
             chai.expect(resp.text).to.include("Found. Redirecting to delivery-details");
         });
     });
+
+    describe("delivery options back button", () => {
+        it("back button takes the user to the certificate options page if they have not selected any options", async () => {
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("certificate-options");
+        });
+
+        it("back button takes the user to the registered office options page if they selected only the registered office option", async () => {
+            const certificateItem = {
+                itemOptions: {
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    }
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("registered-office-options");
+        });
+
+        it("back button takes the user to the director options page if they selected only the director options", async () => {
+            const certificateItem = {
+                itemOptions: {
+                    directorDetails: {
+                        includeBasicInformation: true
+                    }
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("director-options");
+        });
+
+        it("back button takes the user to the secretary options page if they selected only the secretary options", async () => {
+            const certificateItem = {
+                itemOptions: {
+                    secretaryDetails: {
+                        includeBasicInformation: true
+                    }
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("secretary-options");
+        });
+
+        it("back button takes the user to the director options page if they selected both the director options and registered office options", async () => {
+            const certificateItem = {
+                itemOptions: {
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    directorDetails: {
+                        includeBasicInformation: true
+                    }
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("director-options");
+        });
+
+        it("back button takes the user to the secretary options page if they selected the director, secretary and registered office options", async () => {
+            const certificateItem = {
+                itemOptions: {
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    directorDetails: {
+                        includeBasicInformation: true
+                    },
+                    secretaryDetails: {
+                        includeBasicInformation: true
+                    }
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateItem));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.include("secretary-options");
+        });
+    });
+
+    describe("delivery option checked", () => {
+        it("displays checked option", async () => {
+            const certificateDetails = {
+                itemOptions: {
+                    deliveryTimescale: "same-day"
+                }
+            } as CertificateItem;
+
+            getCertificateItemStub = sandbox.stub(apiClient, "getCertificateItem")
+                .returns(Promise.resolve(certificateDetails));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_OPTIONS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.include(`<input class="govuk-radios__input" id="deliveryOptions" name="deliveryOptions" type="radio" value="same-day" checked aria-describedby="deliveryOptions-item-hint" data-event-id="express-delivery">`);
+        });
+    });
 });


### PR DESCRIPTION
pass deliveryTimescale value to delivery options template
display the previously selected value on the delivery option page
add test for displaying of the checked delivery option
move back button tests from delivery details to delivery options as delivery options page is now before delivery details in the journey

Resolves : BI-11192