### PR TITLE
stop defaulting to standard delivery via patch in delivery details

### DIFF
--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -93,7 +93,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
         const certificateItem: CertificateItemPatchRequest = {
             itemOptions: {
                 deliveryMethod: "postal",
-                deliveryTimescale: "standard",
                 forename: firstName,
                 surname: lastName
             }


### PR DESCRIPTION
remove the hardcoded standard delivery selection from the delivery details patching the certificate item