### PR TITLE
GCI-2122: Try limiting originating URL in all cases

### DIFF
--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -34,7 +34,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
                 returnToUrl = replaceCertificateId(LP_CERTIFICATE_OPTIONS, certificateId);
             } else if (originatingUrl.includes("/llp-certificates")) {
                 returnToUrl = replaceCertificateId(LLP_CERTIFICATE_OPTIONS, certificateId);
-            } else {
+            } else if (originatingUrl.includes("/certificates")) {
                 returnToUrl = replaceCertificateId(CERTIFICATE_OPTIONS, certificateId);
             }
             logger.info(`User unauthorized, status_code=401, redirecting to sign in page`);


### PR DESCRIPTION
- This is an attempt to have an impact on the security vulnerabilities reported by SonarQube.
- Unfortunately, it only seems to update these when changes are merged to `master`?