### PR TITLE
update delivery option patch

### DIFF
--- a/src/controllers/certificates/delivery.options.controller.ts
+++ b/src/controllers/certificates/delivery.options.controller.ts
@@ -60,11 +60,21 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
                 errorList: [deliveryOptionsErrorData]
             });
         } else {
-            const certificateItem: CertificateItemPatchRequest = {
-                itemOptions: {
-                    deliveryTimescale: deliveryOption
-                }
-            };
+            let certificateItem: CertificateItemPatchRequest;
+            if (deliveryOption === "standard") {
+                certificateItem = {
+                    itemOptions: {
+                        deliveryTimescale: deliveryOption,
+                        includeEmailCopy: false
+                    }
+                };
+            } else {
+                certificateItem  = {
+                    itemOptions: {
+                        deliveryTimescale: deliveryOption,
+                    }
+                };
+            }
             const certificatePatchResponse = await patchCertificateItem( accessToken, req.params.certificateId, certificateItem);
             logger.info(`Patched certificate item with delivery option, id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);
             if (certificateItem.itemOptions?.deliveryTimescale === "same-day") {


### PR DESCRIPTION
There is a scenario where the user selects express delivery and wants an email copy but then navigates backwards in the journey and now selects standard delivery.  As the api will not allow an email copy selected along with standard delivery this pr clears out the email copy selection if the delivery option is standard in the patch.

Resolves: BI-11192