### PR TITLE
set standard delivery in patch for dissolved cert

### DIFF
--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -90,13 +90,27 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const userId = getUserId(req.session);
         const accessToken: string = getAccessToken(req.session);
-        const certificateItem: CertificateItemPatchRequest = {
-            itemOptions: {
-                deliveryMethod: "postal",
-                forename: firstName,
-                surname: lastName
-            }
-        };
+        const certificateItem: CertificateItem = await getCertificateItem(accessToken, req.params.certificateId);
+        let certificateItemPatch: CertificateItemPatchRequest; 
+        // temporary standard delivery timescale for a dissolved certificate upcoming work to allow same-day
+        if (certificateItem.itemOptions?.certificateType !== "dissolution") {
+            certificateItemPatch = {
+                itemOptions: {
+                    deliveryMethod: "postal",
+                    forename: firstName,
+                    surname: lastName
+                }
+            };
+        } else {
+            certificateItemPatch = {
+                itemOptions: {
+                    deliveryMethod: "postal",
+                    deliveryTimescale : "standard",
+                    forename: firstName,
+                    surname: lastName
+                }
+            };
+        }
         const basketDeliveryDetails: BasketPatchRequest = {
             deliveryDetails: {
                 addressLine1: addressLineOne,
@@ -110,7 +124,7 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             }
         };
         const certificatePatchResponse = await patchCertificateItem(
-            accessToken, req.params.certificateId, certificateItem);
+            accessToken, req.params.certificateId, certificateItemPatch);
         logger.info(`Patched certificate item with delivery details, id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);
         await patchBasket(accessToken, basketDeliveryDetails);
         logger.info(`Patched basket with delivery details, certificate_id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);


### PR DESCRIPTION
set standard delivery in patch for dissolved cert to allow output on check details page, this is temporary as upcoming work will allow this to also be set to same-day

