### PR TITLE
GCI-2122: Try prefixing return to URL with CHS URL

### DIFF
--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -23,6 +23,10 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         }
         const signedIn = req.session?.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.SignedIn] === 1;
 
+        // TODO GCI-2122 Do we need to log these?
+        logger.info(`req.hostname = ${req.hostname}`);
+        logger.info(`signedIn = ${signedIn}`);
+
         if (!signedIn) {
             const certificateId = req.params.certificateId;
             const originatingUrl = req.originalUrl;
@@ -39,7 +43,9 @@ export default async (req: Request, res: Response, next: NextFunction) => {
             }
             logger.info(`User unauthorized, status_code=401, redirecting to sign in page`);
             if (isValidReturnToUrl(returnToUrl)) {
-                return res.redirect(`/signin?return_to=${returnToUrl}`);
+                // TODO GCI-2122 Do we need to log this?
+                logger.info("Redirecting to " + `/signin?return_to=http://chs.local${returnToUrl}`);
+                return res.redirect(`/signin?return_to=http://chs.local${returnToUrl}`);
             }
         } else {
             const accessToken: string = getAccessToken(req.session);

--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -12,7 +12,7 @@ import {
 import { getAccessToken } from "../../session/helper";
 import { createLogger } from "ch-structured-logging";
 
-import {APPLICATION_NAME} from "../../config/config";
+import { APPLICATION_NAME, CHS_URL } from "../../config/config";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -22,10 +22,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
             logger.info(`${req.url}: Session object is missing!`);
         }
         const signedIn = req.session?.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.SignedIn] === 1;
-
-        // TODO GCI-2122 Do we need to log these?
-        logger.info(`req.hostname = ${req.hostname}`);
-        logger.info(`signedIn = ${signedIn}`);
 
         if (!signedIn) {
             const certificateId = req.params.certificateId;
@@ -43,9 +39,8 @@ export default async (req: Request, res: Response, next: NextFunction) => {
             }
             logger.info(`User unauthorized, status_code=401, redirecting to sign in page`);
             if (isValidReturnToUrl(returnToUrl)) {
-                // TODO GCI-2122 Do we need to log this?
-                logger.info("Redirecting to " + `/signin?return_to=http://chs.local${returnToUrl}`);
-                return res.redirect(`/signin?return_to=http://chs.local${returnToUrl}`);
+                logger.info("Redirecting to " + `/signin?return_to=${CHS_URL}${returnToUrl}`);
+                return res.redirect(`/signin?return_to=${CHS_URL}${returnToUrl}`);
             }
         } else {
             const accessToken: string = getAccessToken(req.session);

--- a/test/middleware/certificates/auth.middleware.unit.test.ts
+++ b/test/middleware/certificates/auth.middleware.unit.test.ts
@@ -6,6 +6,7 @@ import { CertificateItem } from "@companieshouse/api-sdk-node/dist/services/orde
 
 import certificateAuthMiddleware from "../../../src/middleware/certificates/auth.middleware";
 import * as apiClient from "../../../src/client/api.client";
+import { CHS_URL } from "../../../src/config/config";
 
 const sandbox = sinon.createSandbox();
 
@@ -76,7 +77,7 @@ describe("certificate.auth.middleware.unit", () => {
         );
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/certificates/0001/certificate-options");
+            .to.have.been.calledWith(`/signin?return_to=${CHS_URL}/orderable/certificates/0001/certificate-options`);
     });
 
     it("should call res.redirect if there is no session for standard certificate", async () => {
@@ -88,7 +89,7 @@ describe("certificate.auth.middleware.unit", () => {
         req.session = undefined;
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/certificates/0001/certificate-options");
+            .to.have.been.calledWith(`/signin?return_to=${CHS_URL}/orderable/certificates/0001/certificate-options`);
     });
 
     it("should call res.redirect if user is not signed in for dissolved certificate", async () => {
@@ -106,7 +107,7 @@ describe("certificate.auth.middleware.unit", () => {
         );
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/dissolved-certificates/0001/delivery-details");
+            .to.have.been.calledWith(`/signin?return_to=${CHS_URL}/orderable/dissolved-certificates/0001/delivery-details`);
     });
 
     it("should call res.redirect if there is no session for dissolved certificate", async () => {
@@ -118,6 +119,6 @@ describe("certificate.auth.middleware.unit", () => {
         req.session = undefined;
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/dissolved-certificates/0001/delivery-details");
+            .to.have.been.calledWith(`/signin?return_to=${CHS_URL}/orderable/dissolved-certificates/0001/delivery-details`);
     });
 });

--- a/test/middleware/certificates/auth.middleware.unit.test.ts
+++ b/test/middleware/certificates/auth.middleware.unit.test.ts
@@ -76,7 +76,7 @@ describe("certificate.auth.middleware.unit", () => {
         );
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certificates/0001/certificate-options");
+            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/certificates/0001/certificate-options");
     });
 
     it("should call res.redirect if there is no session for standard certificate", async () => {
@@ -88,7 +88,7 @@ describe("certificate.auth.middleware.unit", () => {
         req.session = undefined;
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certificates/0001/certificate-options");
+            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/certificates/0001/certificate-options");
     });
 
     it("should call res.redirect if user is not signed in for dissolved certificate", async () => {
@@ -106,7 +106,7 @@ describe("certificate.auth.middleware.unit", () => {
         );
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/0001/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/dissolved-certificates/0001/delivery-details");
     });
 
     it("should call res.redirect if there is no session for dissolved certificate", async () => {
@@ -118,6 +118,6 @@ describe("certificate.auth.middleware.unit", () => {
         req.session = undefined;
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/0001/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=http://chs.local/orderable/dissolved-certificates/0001/delivery-details");
     });
 });


### PR DESCRIPTION
- This is an attempt to have an impact on the security vulnerabilities reported by SonarQube.
- Unfortunately, it only seems to update these when changes are merged to `master`?
- By prefixing the return to  URL with the value of `CHS_URL`, we may be apparently leaving the redirect less open to being pointed at untrusted sites? 