### PR TITLE
add email copy required section to check details page 

### DIFF
--- a/src/controllers/certificates/check-details/LLPCheckDetailsFactory.ts
+++ b/src/controllers/certificates/check-details/LLPCheckDetailsFactory.ts
@@ -32,6 +32,7 @@ export class LLPCheckDetailsFactory implements ViewModelCreatable {
             companyNumber: certificateItem.companyNumber,
             certificateType: this.textMapper.mapCertificateType(itemOptions.certificateType),
             deliveryMethod: this.textMapper.mapDeliveryMethod(itemOptions),
+            emailCopyRequired: this.textMapper.mapEmailCopyRequired(itemOptions),
             fee: this.textMapper.prependCurrencySymbol(certificateItem.itemCosts[0].itemCost),
             changeIncludedOn: replaceCertificateId(LLP_CERTIFICATE_OPTIONS, certificateItem.id),
             changeDeliveryDetails: changeLink,

--- a/src/controllers/certificates/home.controller.ts
+++ b/src/controllers/certificates/home.controller.ts
@@ -151,7 +151,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         if (FEATURE_FLAGS.administrationCompanyCertificateEnabled) {
             acceptableCompanyStatuses.push("administration");
         }
-
         if (allow && acceptableCompanyStatuses.includes(companyStatus)) {
             let landingPage: LandingPage;
 
@@ -167,7 +166,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
                 landingPage = strategy(companyProfile);
             }
 
-            logger.debug(`Rendering ${landingPage}, company_status=${companyStatus}, start_now_url=${landingPage.startNowUrl}, company_number=${companyNumber}, service_url=${landingPage.serviceUrl}, dispatch_days=${DISPATCH_DAYS}, more_tab_url=${moreTabUrl}`);
+            logger.debug(`Rendering ${landingPage.landingPage}, company_status=${companyStatus}, start_now_url=${landingPage.startNowUrl}, company_number=${companyNumber}, service_url=${landingPage.serviceUrl}, dispatch_days=${DISPATCH_DAYS}, more_tab_url=${moreTabUrl}`);
             res.render(landingPage.landingPage, {
                 companyStatus,
                 startNowUrl: landingPage.startNowUrl,

--- a/src/views/certificates/llp-certificates/check-details.html
+++ b/src/views/certificates/llp-certificates/check-details.html
@@ -203,6 +203,21 @@
               },
               {
                 key: {
+                  text: "Email copy required"
+                },
+                value: {
+                  html: emailCopyRequired
+                },
+                actions: {
+                  items: [
+                    {
+                      visuallyHiddenText: "email copy required"
+                    }
+                  ]
+                }
+              },
+              {
+                key: {
                   text: "Delivery details"
                 },
                 value: {
@@ -301,6 +316,21 @@
                     ]
                   }
                 },
+                {
+                key: {
+                  text: "Email copy required"
+                },
+                value: {
+                  html: emailCopyRequired
+                },
+                actions: {
+                  items: [
+                    {
+                      visuallyHiddenText: "email copy required"
+                    }
+                  ]
+                }
+              },
                 {
                   key: {
                     text: "Delivery details"

--- a/test/controller/certificates/check-details/LLPCompanyCheckDetailsFactory.unit.test.ts
+++ b/test/controller/certificates/check-details/LLPCompanyCheckDetailsFactory.unit.test.ts
@@ -7,6 +7,7 @@ import {
     MAPPED_CERTIFICATE_TYPE,
     MAPPED_DELIVERY_DETAILS,
     MAPPED_DELIVERY_METHOD,
+    MAPPED_EMAIL_COPY_REQUIRED,
     MAPPED_FEE, MAPPED_MEMBER_OPTIONS,
     MAPPED_OPTION_VALUE,
     StubDefaultCompanyMappable
@@ -32,6 +33,7 @@ const EXPECTED_RESULT = {
     companyNumber: "12345678",
     certificateType: MAPPED_CERTIFICATE_TYPE,
     deliveryMethod: MAPPED_DELIVERY_METHOD,
+    emailCopyRequired: MAPPED_EMAIL_COPY_REQUIRED,
     fee: MAPPED_FEE,
     changeIncludedOn: "/orderable/llp-certificates/F00DFACE/certificate-options",
     changeDeliveryDetails: "/orderable/llp-certificates/F00DFACE/delivery-details",

--- a/test/controller/certificates/llp-certificates/check.details.controller.integration.test.ts
+++ b/test/controller/certificates/llp-certificates/check.details.controller.integration.test.ts
@@ -58,7 +58,9 @@ describe("LLP certificate.check.details.controller.integration", () => {
                     companyStatus: "active",
                     certificateType: "cert type",
                     forename: "john",
-                    surname: "smith"
+                    surname: "smith",
+                    deliveryTimescale: "standard",
+                    includeEmailCopy: false
                 }
             } as CertificateItem;
 
@@ -76,7 +78,9 @@ describe("LLP certificate.check.details.controller.integration", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect($(".govuk-heading-xl").text()).to.equal("Check your order details");
             chai.expect($("#orderDetails").text()).to.equal("Order details");
-            chai.expect($(".govuk-summary-list__row:nth-of-type(4)").find(".govuk-summary-list__key").text().trim()).to.equal("Statement of good standing");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(4)").find(".govuk-summary-list__key").text().trim()).to.include("Statement of good standing");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__key").text().trim()).to.include("Email copy required");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__value").text().trim()).to.include("Email only available for express delivery method");
         });
 
         it("renders the check details screen for an LLP in liquidation", async () => {
@@ -91,6 +95,8 @@ describe("LLP certificate.check.details.controller.integration", () => {
                     certificateType: "cert type",
                     forename: "john",
                     surname: "smith",
+                    deliveryTimescale: "standard",
+                    includeEmailCopy: false,
                     liquidatorsDetails: {
                         includeBasicInformation: true
                     }
@@ -113,6 +119,8 @@ describe("LLP certificate.check.details.controller.integration", () => {
             chai.expect($("#orderDetails").text()).to.equal("Order details");
             chai.expect($(".govuk-summary-list__row:nth-of-type(7)").find(".govuk-summary-list__key").text().trim()).to.equal("Liquidators' details");
             chai.expect($(".liquidators").text().trim()).to.equal("Yes");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__key").text().trim()).to.include("Email copy required");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__value").text().trim()).to.include("Email only available for express delivery method");
         });
 
         it("renders the check details screen for an LLP in administration", async () => {
@@ -127,6 +135,8 @@ describe("LLP certificate.check.details.controller.integration", () => {
                     certificateType: "cert type",
                     forename: "john",
                     surname: "smith",
+                    deliveryTimescale: "standard",
+                    includeEmailCopy: false,
                     administratorsDetails: {
                         includeBasicInformation: true
                     }
@@ -149,6 +159,8 @@ describe("LLP certificate.check.details.controller.integration", () => {
             chai.expect($("#orderDetails").text()).to.equal("Order details");
             chai.expect($(".govuk-summary-list__row:nth-of-type(7)").find(".govuk-summary-list__key").text().trim()).to.equal("Administrators' details");
             chai.expect($(".administrators").text().trim()).to.equal("Yes");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__key").text().trim()).to.include("Email copy required");
+            chai.expect($(".govuk-summary-list__row:nth-of-type(2)").find(".govuk-summary-list__value").text().trim()).to.include("Email only available for express delivery method");
         });
     });
 
@@ -310,6 +322,7 @@ describe("LLP certificate.check.details.controller.integration", () => {
             chai.expect(resp.status).to.equal(200);
             chai.expect(resp.text).not.to.contain("Included on certificate");
             chai.expect(resp.text).to.contain("Dissolution with all company name changes");
+            chai.expect(resp.text).to.contain("Email copy required");
         });
     });
 


### PR DESCRIPTION
add email copy required section to check details page ensuring this shows for dissolved llps and llps which are in administration or liquidation

Resolves: BI-11261