### PR TITLE
GCI-2157 conditional redirects for certificates journey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.18.tgz",
-      "integrity": "sha512-1d/c0PL1ynrI6dV7zNu1P4/I81seMSvj7loi/RJzUuIX25EtCzvHBx4XiylKh0LGkVkV3EPj2EpVLAs3VADVVA==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.21.tgz",
+      "integrity": "sha512-ZBUctruqCpmjTZm85/ahTjBpLjYh4vZ5nwso9K3l4g9tZzIr2NsFwqgQ2o5xGeiz1CKR0c/rPvgUm+10wGAwwQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -1367,7 +1367,7 @@
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "moment": {
           "version": "2.26.0",
@@ -1377,7 +1377,7 @@
         "one-time": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
-          "integrity": "sha512-qAMrwuk2xLEutlASoiPiAMW3EN3K96Ka/ilSXYr6qR1zSVXw2j7+yDSqGTC4T9apfLYxM3tLLjKvgPdAUK7kYQ=="
+          "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
         },
         "winston": {
           "version": "3.2.1",
@@ -1750,7 +1750,7 @@
     "colornames": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-      "integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
       "version": "1.4.0",
@@ -2350,7 +2350,7 @@
         "enabled": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-          "integrity": "sha512-nnzgVSpB35qKrUN8358SjO1bYAmxoThECTWw9s3J0x5G8A9hokKHVDFzBjVpCoSryo6MhN8woVyascN5jheaNA==",
+          "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
           "requires": {
             "env-variable": "0.0.x"
           }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.18",
+    "@companieshouse/api-sdk-node": "^2.0.21",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "~1.4.4",

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -3,7 +3,7 @@ import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/compa
 import {
     Basket,
     BasketPatchRequest,
-    ItemUriPostRequest
+    ItemUriRequest
 } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import {
     CertificateItem,
@@ -69,13 +69,23 @@ export const getCertificateItem = async (oAuth: string, certificateId: string): 
     return certificateItemResource.value.resource as CertificateItem;
 };
 
-export const addItemToBasket = async (oAuth: string, itemUri: ItemUriPostRequest): Promise<BasketItem> => {
+export const addItemToBasket = async (oAuth: string, itemUri: ItemUriRequest): Promise<BasketItem> => {
     const api = createApiClient(undefined, oAuth, API_URL);
     const itemUriResource: Resource<BasketItem> = await api.basket.postItemToBasket(itemUri);
     if (itemUriResource.httpStatusCode !== 200 && itemUriResource.httpStatusCode !== 201) {
         throw createError(itemUriResource.httpStatusCode, itemUriResource.httpStatusCode.toString());
     }
     logger.info(`Add item to basket, status_code=${itemUriResource.httpStatusCode}, company_number=${itemUriResource.resource?.companyNumber}`);
+    return itemUriResource.resource as BasketItem;
+};
+
+export const appendItemToBasket = async (oAuth: string, itemUri: ItemUriRequest): Promise<BasketItem> => {
+    const api = createApiClient(undefined, oAuth, API_URL);
+    const itemUriResource: Resource<BasketItem> = await api.basket.appendItemToBasket(itemUri);
+    if (itemUriResource.httpStatusCode !== 200 && itemUriResource.httpStatusCode !== 201) {
+        throw createError(itemUriResource.httpStatusCode, itemUriResource.httpStatusCode.toString());
+    }
+    logger.info(`Append item to basket, status_code=${itemUriResource.httpStatusCode}, company_number=${itemUriResource.resource?.companyNumber}`);
     return itemUriResource.resource as BasketItem;
 };
 

--- a/src/controllers/certificates/StaticRedirectCallback.ts
+++ b/src/controllers/certificates/StaticRedirectCallback.ts
@@ -1,0 +1,25 @@
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { Response } from "express";
+
+export class StaticRedirectCallback {
+    private readonly deliverableItemPredicate: (item: Item) => boolean;
+
+    constructor (deliverableItemFilter: (item: Item) => boolean) {
+        this.deliverableItemPredicate = deliverableItemFilter;
+    }
+
+    redirectEnrolled (request: EnrolledRedirectRequest) {
+        if ((request.items || []).find(this.deliverableItemPredicate)) {
+            return request.response.redirect("/basket");
+        } else {
+            return request.response.redirect("/delivery-details");
+        }
+    }
+}
+
+export const BY_ITEM_KIND = item => item.kind === "item#certificate" || item.kind === "item#certified-copy";
+
+export class EnrolledRedirectRequest {
+    items?: Item[];
+    response: Response;
+}

--- a/src/controllers/certificates/email.options.controller.ts
+++ b/src/controllers/certificates/email.options.controller.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { check, validationResult } from "express-validator";
 import { CertificateItem, CertificateItemPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { getAccessToken, getUserId } from "../../session/helper";
-import { getCertificateItem, patchCertificateItem } from "../../client/api.client";
+import { appendItemToBasket, getBasket, getCertificateItem, patchCertificateItem } from "../../client/api.client";
 import { DELIVERY_DETAILS, DELIVERY_OPTIONS, EMAIL_OPTIONS } from "../../model/template.paths";
 import { createLogger } from "ch-structured-logging";
 import { APPLICATION_NAME } from "../../config/config";
@@ -10,6 +10,7 @@ import { setServiceUrl } from "../../utils/service.url.utils";
 import { Session } from "@companieshouse/node-session-handler";
 import { EMAIL_OPTION_SELECTION } from "../../model/error.messages";
 import { createGovUkErrorData } from "../../model/govuk.error.data";
+import { BY_ITEM_KIND, StaticRedirectCallback } from "./StaticRedirectCallback";
 
 const EMAIL_OPTION_FIELD: string = "emailOptions";
 const PAGE_TITLE: string = "Email options - Order a certificate - GOV.UK";
@@ -18,6 +19,8 @@ const logger = createLogger(APPLICATION_NAME);
 const validators = [
     check("emailOptions").not().isEmpty().withMessage(EMAIL_OPTION_SELECTION)
 ];
+
+const redirectCallback = new StaticRedirectCallback(BY_ITEM_KIND);
 
 export const render = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -58,13 +61,21 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
                 errorList: [emailOptionsErrorData]
             });
         } else {
-            const certificateItem: CertificateItemPatchRequest = {
+            const certificateItemPatchRequest: CertificateItemPatchRequest = {
                 itemOptions: {
                     includeEmailCopy: emailOption
                 }
             };
-            const certificatePatchResponse = await patchCertificateItem(accessToken, req.params.certificateId, certificateItem);
+            const certificatePatchResponse = await patchCertificateItem(accessToken, req.params.certificateId, certificateItemPatchRequest);
             logger.info(`Patched certificate item with email option, id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);
+            const basket = await getBasket(accessToken);
+            if (basket.enrolled) {
+                await appendItemToBasket(accessToken, { itemUri: certificateItem.links.self });
+                return redirectCallback.redirectEnrolled({
+                    response: res,
+                    items: basket.items
+                });
+            }
             return res.redirect(DELIVERY_DETAILS);
         }
     } catch (err) {

--- a/test/client/api.client.unit.test.ts
+++ b/test/client/api.client.unit.test.ts
@@ -17,6 +17,8 @@ import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/or
 import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
 import {
+    addItemToBasket,
+    appendItemToBasket,
     getBasket,
     getCertificateItem,
     getCertifiedCopyItem,
@@ -33,6 +35,7 @@ import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/compa
 import { MidService } from "@companieshouse/api-sdk-node/dist/services/order";
 import { MidItem, MidItemPostRequest } from "@companieshouse/api-sdk-node/dist/services/order/mid/types";
 import { failure, success, Success } from "@companieshouse/api-sdk-node/dist/services/result";
+import createError, { NotFound } from "http-errors";
 
 const dummyBasketSDKResponse: Resource<Basket> = {
     httpStatusCode: 200,
@@ -477,6 +480,52 @@ describe("api.client", () => {
                 .returns(Promise.resolve(dummyMissingImageDeliveryItemSDKResponse));
             const missingImageDeliveryItem = await getMissingImageDeliveryItem("oauth", "MID-360615-955167");
             chai.expect(missingImageDeliveryItem).to.equal(dummyMissingImageDeliveryItemSDKResponse.resource);
+        });
+    });
+
+    describe("addItemToBasket", () => {
+        it("Sends a POST request to the addItemToBasket endpoint", async () => {
+            const item: any = {
+                companyNumber: "12345678"
+            };
+            sandbox.stub(BasketService.prototype, "postItemToBasket")
+                .returns(Promise.resolve({
+                    resource: item,
+                    httpStatusCode: 200
+                }));
+            const addItemToBasketResult = await addItemToBasket("oauth", { itemUri: "/path/to/item" });
+            chai.expect(addItemToBasketResult).to.equal(item);
+        });
+
+        it("Throws an error if error returned by service", async () => {
+            sandbox.stub(BasketService.prototype, "postItemToBasket")
+                .returns(Promise.resolve({
+                    httpStatusCode: 404
+                }));
+            await chai.expect(addItemToBasket("oauth", { itemUri: "/path/to/item" })).to.be.rejectedWith(NotFound);
+        });
+    });
+
+    describe("appendItemToBasket", () => {
+        it("Sends a POST request to the appendItemToBasket endpoint", async () => {
+            const item: any = {
+                companyNumber: "12345678"
+            };
+            sandbox.stub(BasketService.prototype, "appendItemToBasket")
+                .returns(Promise.resolve({
+                    resource: item,
+                    httpStatusCode: 200
+                }));
+            const appendItemToBasketResult = await appendItemToBasket("oauth", { itemUri: "/path/to/item" });
+            chai.expect(appendItemToBasketResult).to.equal(item);
+        });
+
+        it("Throws an error if error returned by service", async () => {
+            sandbox.stub(BasketService.prototype, "appendItemToBasket")
+                .returns(Promise.resolve({
+                    httpStatusCode: 404
+                }));
+            await chai.expect(appendItemToBasket("oauth", { itemUri: "/path/to/item" })).to.be.rejectedWith(NotFound);
         });
     });
 });

--- a/test/controller/certificates/StaticRedirectCallback.unit.test.ts
+++ b/test/controller/certificates/StaticRedirectCallback.unit.test.ts
@@ -1,0 +1,42 @@
+import { StaticRedirectCallback } from "../../../src/controllers/certificates/StaticRedirectCallback";
+import { expect } from "chai";
+import { createSandbox } from "sinon";
+
+describe("StaticRedirectCallback", () => {
+
+    const sandbox = createSandbox();
+
+    describe("redirectEnrolled", () => {
+        it("Redirects user agent to the basket page if predicate evaluates to true", () => {
+            // given
+            const callback = new StaticRedirectCallback(() => true);
+            const mockResponse = sandbox.spy({
+                redirect: (path: string) => {}
+            });
+            // when
+            callback.redirectEnrolled({
+                response: mockResponse,
+                items: [{}]
+            } as any);
+
+            // then
+            expect(mockResponse.redirect).to.be.calledOnceWith("/basket");
+        });
+
+        it("Redirects user agent to the delivery details page if predicate evaluates to false", () => {
+            // given
+            const callback = new StaticRedirectCallback(() => false);
+            const mockResponse = sandbox.spy({
+                redirect: (path: string) => {}
+            });
+            // when
+            callback.redirectEnrolled({
+                response: mockResponse,
+                items: [{}]
+            } as any);
+
+            // then
+            expect(mockResponse.redirect).to.be.calledOnceWith("/delivery-details");
+        });
+    });
+});


### PR DESCRIPTION
* Delivery and email options controllers now call new appendItemToBasket endpoint
  if user enrolled for multi-item basket and basket already contains
  deliverable items.
* User agent redirected to global delivery details page when
  continuing from delivery options or email options pages and no
  deliverable items in basket.
* User agent redirected to basket page when continuing from delivery
  options or email options pages and deliverable items already in
  basket.

Resolves:
[GCI-2157](https://companieshouse.atlassian.net/browse/GCI-2157)