### PR TITLE
BI-11519: jQuery $ allows click() callback to be set correctly?

### DIFF
--- a/static/js/mobile-menu.js
+++ b/static/js/mobile-menu.js
@@ -1,6 +1,6 @@
 window.addEventListener('DOMContentLoaded', (event) => {
     document.querySelector("ul#navigation").classList.add("mobile-hidden");
-    document.querySelector(".js-toggle-nav.js-header-toggle").click(() => {
+    $(".js-toggle-nav .js-header-toggle").click(() => {
         event.preventDefault();
         document.querySelector("ul#navigation").classList.toggle("mobile-hidden");
         document.querySelector("#global-nav").classList.toggle("open");


### PR DESCRIPTION
* The jQuery `$` version returns some complex wrapping object for the element, the `document.querySelector` version just returns the targeted element.
* However, I don't know why the former seems to work in this case, whilst the latter seems not to work.