### PR TITLE
add correct redirect for dissolved certs and cert copies

### DIFF
--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -6,8 +6,7 @@ import { getCertificateItem } from "../../client/api.client";
 import {
     CERTIFICATE_OPTIONS,
     replaceCertificateId,
-    DISSOLVED_CERTIFICATE_DELIVERY_DETAILS,
-    LP_CERTIFICATE_OPTIONS, LLP_CERTIFICATE_OPTIONS
+    LP_CERTIFICATE_OPTIONS, LLP_CERTIFICATE_OPTIONS, DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS
 } from "../../model/page.urls";
 import { getAccessToken } from "../../session/helper";
 import { createLogger } from "ch-structured-logging";
@@ -30,7 +29,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
             let returnToUrl;
 
             if (originatingUrl.includes("/dissolved-certificates")) {
-                returnToUrl = replaceCertificateId(DISSOLVED_CERTIFICATE_DELIVERY_DETAILS, certificateId);
+                returnToUrl = replaceCertificateId(DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS, certificateId);
             } else if (originatingUrl.includes("/lp-certificates")) {
                 returnToUrl = replaceCertificateId(LP_CERTIFICATE_OPTIONS, certificateId);
             } else if (originatingUrl.includes("/llp-certificates")) {

--- a/src/middleware/certificates/auth.middleware.ts
+++ b/src/middleware/certificates/auth.middleware.ts
@@ -6,7 +6,9 @@ import { getCertificateItem } from "../../client/api.client";
 import {
     CERTIFICATE_OPTIONS,
     replaceCertificateId,
-    LP_CERTIFICATE_OPTIONS, LLP_CERTIFICATE_OPTIONS, DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS
+    LP_CERTIFICATE_OPTIONS, 
+    LLP_CERTIFICATE_OPTIONS,
+    DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS
 } from "../../model/page.urls";
 import { getAccessToken } from "../../session/helper";
 import { createLogger } from "ch-structured-logging";

--- a/src/middleware/certified-copies/auth.middleware.ts
+++ b/src/middleware/certified-copies/auth.middleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from "express";
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { getUserId } from "../../session/helper";
-import { CERTIFIED_COPY_DELIVERY_DETAILS, replaceCertifiedCopyId } from "../../model/page.urls";
+import { CERTIFIED_COPY_DELIVERY_OPTIONS, replaceCertifiedCopyId } from "../../model/page.urls";
 
 import { createLogger } from "ch-structured-logging";
 
@@ -21,7 +21,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 
         if (!signedIn) {
             const certifiedCopyId = req.params.certifiedCopyId;
-            const returnToUrl = replaceCertifiedCopyId(CERTIFIED_COPY_DELIVERY_DETAILS, certifiedCopyId);
+            const returnToUrl = replaceCertifiedCopyId(CERTIFIED_COPY_DELIVERY_OPTIONS, certifiedCopyId);
             logger.info(`User unauthorized, status_code=401, redirecting to sign in page`);
             return res.redirect(`/signin?return_to=${getWhitelistedReturnToURL(returnToUrl)}`);
         } else {

--- a/src/utils/request.util.ts
+++ b/src/utils/request.util.ts
@@ -7,7 +7,9 @@ export const CERTIFICATE_OPTIONS_RE = /\/orderable\/certificates\/CRT-\d{6}-\d{6
 export const LP_CERTIFICATE_OPTIONS_RE = /\/orderable\/lp-certificates\/CRT-\d{6}-\d{6}\/certificate-options/;
 export const LLP_CERTIFICATE_OPTIONS_RE = /\/orderable\/llp-certificates\/CRT-\d{6}-\d{6}\/certificate-options/;
 export const CERTIFIED_COPIES_DELIVERY_DETAILS_RE = /\/orderable\/certified-copies\/CCD-\d{6}-\d{6}\/delivery-details/;
+export const CERTIFIED_COPIES_DELIVERY_OPTIONS_RE = /\/orderable\/certified-copies\/CCD-\d{6}-\d{6}\/delivery-options/;
 export const DISSOLVED_CERTIFICATE_DELIVERY_DETAILS_RE = /\/orderable\/dissolved-certificates\/CRT-\d{6}-\d{6}\/delivery-details/;
+export const DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS_RE = /\/orderable\/dissolved-certificates\/CRT-\d{6}-\d{6}\/delivery-options/;
 export const MISSING_IMAGE_DELIVERY_CREATE_RE = /\/company\/[A-Z0-9]{8}\/orderable\/missing-image-deliveries\/[a-zA-Z0-9]{8,}\/create/;
 export const MISSING_IMAGE_DELIVERY_CHECK_DETAILS_RE = /\/orderable\/missing-image-deliveries\/MID-\d{6}-\d{6}\/check-details/;
 const REDIRECTS_WHITELIST: RegExp[] = [
@@ -15,7 +17,9 @@ const REDIRECTS_WHITELIST: RegExp[] = [
     LP_CERTIFICATE_OPTIONS_RE,
     LLP_CERTIFICATE_OPTIONS_RE,
     CERTIFIED_COPIES_DELIVERY_DETAILS_RE,
+    CERTIFIED_COPIES_DELIVERY_OPTIONS_RE,
     DISSOLVED_CERTIFICATE_DELIVERY_DETAILS_RE,
+    DISSOLVED_CERTIFICATE_DELIVERY_OPTIONS_RE,
     MISSING_IMAGE_DELIVERY_CREATE_RE,
     MISSING_IMAGE_DELIVERY_CHECK_DETAILS_RE];
 

--- a/test/middleware/certificates/auth.middleware.unit.test.ts
+++ b/test/middleware/certificates/auth.middleware.unit.test.ts
@@ -106,7 +106,7 @@ describe("certificate.auth.middleware.unit", () => {
         );
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/CRT-837816-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/CRT-837816-028323/delivery-options");
     });
 
     it("should call res.redirect if there is no session for dissolved certificate", async () => {
@@ -118,6 +118,6 @@ describe("certificate.auth.middleware.unit", () => {
         req.session = undefined;
         await certificateAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/CRT-837816-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/dissolved-certificates/CRT-837816-028323/delivery-options");
     });
 });

--- a/test/middleware/certified-copies/auth.middleware.unit.test.ts
+++ b/test/middleware/certified-copies/auth.middleware.unit.test.ts
@@ -19,6 +19,34 @@ describe("certified-copy.auth.middleware.unit", () => {
         sandbox.restore();
     });
 
+    it("should call res.redirect if user is not signed in and trying to access the delivery options page", async () => {
+        const req = {
+            path: "/delivery-options"
+        } as Request;
+        req.params = { certifiedCopyId: "CCD-228916-028323" };
+        req.session = new Session(
+            {
+                signin_info: {
+                    signed_in: 0
+                }
+            }
+        );
+        await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
+        chai.expect(redirectSpy)
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
+    });
+
+    it("should call res.redirect if there an attempt to access the delivery options page with no session", async () => {
+        const req = {
+            path: "/delivery-options"
+        } as Request;
+        req.params = { certifiedCopyId: "CCD-228916-028323" };
+        req.session = undefined;
+        await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
+        chai.expect(redirectSpy)
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
+    });
+
     it("should call res.redirect if user is not signed in and trying to access the delivery details page", async () => {
         const req = {
             path: "/delivery-details"
@@ -33,7 +61,7 @@ describe("certified-copy.auth.middleware.unit", () => {
         );
         await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
     });
 
     it("should call res.redirect if there an attempt to access the delivery details page with no session", async () => {
@@ -44,7 +72,7 @@ describe("certified-copy.auth.middleware.unit", () => {
         req.session = undefined;
         await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
     });
 
     it("should call res.redirect if user is not signed in and trying to access the check details page", async () => {
@@ -61,7 +89,7 @@ describe("certified-copy.auth.middleware.unit", () => {
         );
         await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
     });
 
     it("should call res.redirect if there an attempt to access the check details page with no session", async () => {
@@ -72,6 +100,6 @@ describe("certified-copy.auth.middleware.unit", () => {
         req.session = undefined;
         await certifiedCopyAuthMiddleware(req, res, nextFunctionSpy);
         chai.expect(redirectSpy)
-            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-details");
+            .to.have.been.calledWith("/signin?return_to=/orderable/certified-copies/CCD-228916-028323/delivery-options");
     });
 });

--- a/test/utils/request.util.unit.test.ts
+++ b/test/utils/request.util.unit.test.ts
@@ -166,7 +166,9 @@ describe("request.util.unit",
                     "/\\/orderable\\/lp-certificates\\/CRT-\\d{6}-\\d{6}\\/certificate-options/," +
                     "/\\/orderable\\/llp-certificates\\/CRT-\\d{6}-\\d{6}\\/certificate-options/," +
                     "/\\/orderable\\/certified-copies\\/CCD-\\d{6}-\\d{6}\\/delivery-details/," +
+                    "/\\/orderable\\/certified-copies\\/CCD-\\d{6}-\\d{6}\\/delivery-options/," +
                     "/\\/orderable\\/dissolved-certificates\\/CRT-\\d{6}-\\d{6}\\/delivery-details/," +
+                    "/\\/orderable\\/dissolved-certificates\\/CRT-\\d{6}-\\d{6}\\/delivery-options/," +
                     "/\\/company\\/[A-Z0-9]{8}\\/orderable\\/missing-image-deliveries\\/[a-zA-Z0-9]{8,}\\/create/," +
                     "/\\/orderable\\/missing-image-deliveries\\/MID-\\d{6}-\\d{6}\\/check-details/.");
             });


### PR DESCRIPTION
add correct redirect for dissolved certs and cert copies to delivery options page add urls to whitelist update tests

Resolves: BI-11697