### PR TITLE
BI-11726: Introduce company name to certified copies delivery page

### DIFF
--- a/src/controllers/certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/delivery.details.controller.ts
@@ -26,7 +26,6 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         logger.info(`Get certificate item, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
         return res.render(DELIVERY_DETAILS, {
             companyName: basket.deliveryDetails?.companyName,
-            displayCompanyName: true,
             firstName: basket.deliveryDetails?.forename,
             lastName: basket.deliveryDetails?.surname,
             addressLineOne: basket.deliveryDetails?.addressLine1,
@@ -75,7 +74,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             addressTown,
             companyNumber: certificateItem.companyNumber,
             companyName,
-            displayCompanyName: true,
             firstName,
             lastName,
             pageTitle: PAGE_TITLE,

--- a/src/controllers/certificates/llp-certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/llp-certificates/delivery.details.controller.ts
@@ -27,7 +27,6 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         logger.info(`Get certificate item, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
         return res.render(DELIVERY_DETAILS, {
             companyName: basket.deliveryDetails?.companyName,
-            displayCompanyName: true,
             firstName: basket.deliveryDetails?.forename,
             lastName: basket.deliveryDetails?.surname,
             addressLineOne: basket.deliveryDetails?.addressLine1,
@@ -76,7 +75,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             addressTown,
             companyNumber: certificateItem.companyNumber,
             companyName,
-            displayCompanyName: true,
             firstName,
             lastName,
             pageTitle: PAGE_TITLE,

--- a/src/controllers/certificates/lp-certificates/delivery.details.controller.ts
+++ b/src/controllers/certificates/lp-certificates/delivery.details.controller.ts
@@ -27,7 +27,6 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         logger.info(`Get certificate item, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
         return res.render(DELIVERY_DETAILS, {
             companyName: basket.deliveryDetails?.companyName,
-            displayCompanyName: true,
             firstName: basket.deliveryDetails?.forename,
             lastName: basket.deliveryDetails?.surname,
             addressLineOne: basket.deliveryDetails?.addressLine1,
@@ -76,7 +75,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             addressTown,
             companyNumber: certificateItem.companyNumber,
             companyName,
-            displayCompanyName: true,
             firstName,
             lastName,
             pageTitle: PAGE_TITLE,

--- a/src/controllers/certified-copies/delivery.details.controller.ts
+++ b/src/controllers/certified-copies/delivery.details.controller.ts
@@ -9,16 +9,9 @@ import { APPLICATION_NAME } from "../../config/config";
 import { getBasket, patchBasket, getCertifiedCopyItem } from "../../client/api.client";
 import { deliveryDetailsValidationRules, validate } from "../../utils/delivery-details-validation";
 import { CertifiedCopyItem } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies/types";
+import { DeliveryDetailsPropertyName } from "../certificates/model/DeliveryDetailsPropertyName";
 const escape = require("escape-html");
 
-const FIRST_NAME_FIELD: string = "firstName";
-const LAST_NAME_FIELD: string = "lastName";
-const ADDRESS_LINE_ONE_FIELD: string = "addressLineOne";
-const ADDRESS_LINE_TWO_FIELD: string = "addressLineTwo";
-const ADDRESS_TOWN_FIELD: string = "addressTown";
-const ADDRESS_COUNTY_FIELD: string = "addressCounty";
-const ADDRESS_POSTCODE_FIELD: string = "addressPostcode";
-const ADDRESS_COUNTRY_FIELD: string = "addressCountry";
 const PAGE_TITLE: string = "Delivery details - Order a certified document - GOV.UK";
 
 const logger = createLogger(APPLICATION_NAME);
@@ -37,6 +30,7 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         return res.render(DELIVERY_DETAILS, {
             firstName: basket.deliveryDetails?.forename,
             lastName: basket.deliveryDetails?.surname,
+            companyName: basket.deliveryDetails?.companyName,
             addressLineOne: basket.deliveryDetails?.addressLine1,
             addressLineTwo: basket.deliveryDetails?.addressLine2,
             addressCountry: basket.deliveryDetails?.country,
@@ -64,14 +58,15 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
     const backLink: string = `/orderable/certified-copies/${certifiedCopyItemId}/delivery-options`;
     const errors = validationResult(req);
     const errorList = validate(errors);
-    const firstName: string = req.body[FIRST_NAME_FIELD];
-    const lastName: string = req.body[LAST_NAME_FIELD];
-    const addressLineOne: string = req.body[ADDRESS_LINE_ONE_FIELD];
-    const addressLineTwo: string = req.body[ADDRESS_LINE_TWO_FIELD];
-    const addressTown: string = req.body[ADDRESS_TOWN_FIELD];
-    const addressCounty: string = req.body[ADDRESS_COUNTY_FIELD];
-    const addressPostcode: string = req.body[ADDRESS_POSTCODE_FIELD];
-    const addressCountry: string = req.body[ADDRESS_COUNTRY_FIELD];
+    const firstName: string = req.body[DeliveryDetailsPropertyName.FIRST_NAME];
+    const lastName: string = req.body[DeliveryDetailsPropertyName.LAST_NAME];
+    const companyName: string = req.body[DeliveryDetailsPropertyName.COMPANY_NAME];
+    const addressLineOne: string = req.body[DeliveryDetailsPropertyName.ADDRESS_LINE_ONE];
+    const addressLineTwo: string = req.body[DeliveryDetailsPropertyName.ADDRESS_LINE_TWO];
+    const addressTown: string = req.body[DeliveryDetailsPropertyName.ADDRESS_TOWN];
+    const addressCounty: string = req.body[DeliveryDetailsPropertyName.ADDRESS_COUNTY];
+    const addressPostcode: string = req.body[DeliveryDetailsPropertyName.ADDRESS_POSTCODE];
+    const addressCountry: string = req.body[DeliveryDetailsPropertyName.ADDRESS_COUNTRY];
     const SERVICE_URL = `/company/${companyNumber}/orderable/certified-copies`;
 
     if (!errors.isEmpty()) {
@@ -83,6 +78,7 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             addressLineTwo,
             addressPostcode,
             addressTown,
+            companyName,
             firstName,
             lastName,
             backLink,
@@ -99,6 +95,7 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             deliveryDetails: {
                 addressLine1: addressLineOne,
                 addressLine2: addressLineTwo || null,
+                companyName: companyName || null,
                 country: addressCountry,
                 forename: firstName,
                 locality: addressTown,

--- a/src/views/delivery-details.html
+++ b/src/views/delivery-details.html
@@ -61,7 +61,6 @@
         errorMessage: lastNameError
         }) }}
 
-      {% if displayCompanyName %}
         {{ govukInput({
           label: {
             text: "Company name"
@@ -72,7 +71,6 @@
         value: companyName,
         errorMessage: companyNameError
         }) }}
-      {% endif %}
 
         {{ govukInput({
           label: {

--- a/test/controller/certified-copies/delivery.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/delivery.details.controller.integration.test.ts
@@ -14,6 +14,7 @@ const ENTER_YOUR_LAST_NAME_NOT_INPUT = "Enter your last name";
 const ENTER_BUILDING_AND_STREET_LINE_ONE = "Enter a building and street";
 const FIRST_NAME_INVALID_CHARACTER_ERROR = "First name cannot include";
 const LAST_NAME_INVALID_CHARACTER_ERROR = "Last name cannot include";
+const COMPANY_NAME_INVALID_CHARACTER_ERROR = "Company name cannot include";
 const ADDRESS_LINE_ONE_INVALID_CHARACTERS_ERROR: string = "Address line 1 cannot include ";
 const ADDRESS_LINE_TWO_INVALID_CHARACTERS_ERROR: string = "Address line 2 cannot include ";
 const ADDRESS_TOWN_INVALID_CHARACTERS_ERROR: string = "Town or city cannot include ";
@@ -55,6 +56,7 @@ describe("certified.copies.delivery.details.controller", () => {
                 deliveryDetails: {
                     forename: "john",
                     surname: "smith",
+                    companyName: "company name",
                     addressLine1: "117 kings road",
                     addressLine2: "pontcanna",
                     country: "wales",
@@ -73,6 +75,7 @@ describe("certified.copies.delivery.details.controller", () => {
 
             chai.expect(res.status).to.equal(200);
             chai.expect(res.text).to.contain("What are the delivery details?");
+            chai.expect(res.text).to.contain("company name");
         });
     });
 
@@ -108,7 +111,8 @@ describe("certified.copies.delivery.details.controller", () => {
                     addressPostcode: INVALID_CHARACTER,
                     addressTown: INVALID_CHARACTER,
                     firstName: INVALID_CHARACTER,
-                    lastName: INVALID_CHARACTER
+                    lastName: INVALID_CHARACTER,
+                    companyName: INVALID_CHARACTER
                 })
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
 
@@ -121,6 +125,8 @@ describe("certified.copies.delivery.details.controller", () => {
             chai.expect(res.text).to.contain(ADDRESS_COUNTY_INVALID_CHARACTERS_ERROR);
             chai.expect(res.text).to.contain(ADDRESS_POSTCODE_INVALID_CHARACTERS_ERROR);
             chai.expect(res.text).to.contain(ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(COMPANY_NAME_INVALID_CHARACTER_ERROR);
         });
 
         it("should receive error messages requesting less than allowed character length in input fields", async () => {
@@ -136,7 +142,8 @@ describe("certified.copies.delivery.details.controller", () => {
                     addressPostcode: CHARACTER_LENGTH_TEXT_50,
                     addressTown: CHARACTER_LENGTH_TEXT_50,
                     firstName: CHARACTER_LENGTH_TEXT_50,
-                    lastName: CHARACTER_LENGTH_TEXT_50
+                    lastName: CHARACTER_LENGTH_TEXT_50,
+                    companyName: CHARACTER_LENGTH_TEXT_50
                 })
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
 
@@ -149,6 +156,7 @@ describe("certified.copies.delivery.details.controller", () => {
             chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTY_MAX_LENGTH);
             chai.expect(res.text).to.contain(errorMessages.ADDRESS_POSTCODE_MAX_LENGTH);
             chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTRY_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ORDER_DETAILS_COMPANY_NAME_MAX_LENGTH);
         });
 
         it("should not receive Postcode or county error message when postcode is input", async () => {
@@ -196,6 +204,7 @@ describe("certified.copies.delivery.details.controller", () => {
                     addressLineTwo: "Pontcanna",
                     addressPostcode: "CF11 9VE",
                     addressTown: "CARDIFF",
+                    companyName: "Ink Inc",
                     firstName: "JOHN",
                     lastName: "SMITH"
                 })

--- a/test/controller/certified-copies/delivery.details.controller.integration.test.ts
+++ b/test/controller/certified-copies/delivery.details.controller.integration.test.ts
@@ -125,7 +125,6 @@ describe("certified.copies.delivery.details.controller", () => {
             chai.expect(res.text).to.contain(ADDRESS_COUNTY_INVALID_CHARACTERS_ERROR);
             chai.expect(res.text).to.contain(ADDRESS_POSTCODE_INVALID_CHARACTERS_ERROR);
             chai.expect(res.text).to.contain(ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR);
-            chai.expect(res.text).to.contain(ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR);
             chai.expect(res.text).to.contain(COMPANY_NAME_INVALID_CHARACTER_ERROR);
         });
 


### PR DESCRIPTION
* Revert the bug fix for GCI-2318, implemented earlier precisely to exclude this field from the page for certified copies.
* Plumb company name into the certified copies delivery details controller.

**This PR must not be merged until the story is brought into the sprint.**