### PR TITLE
BI-11727: Add company name to check your order details page

### DIFF
--- a/src/utils/check.details.utils.ts
+++ b/src/utils/check.details.utils.ts
@@ -12,6 +12,11 @@ export const mapDeliveryDetails = (deliveryDetails: DeliveryDetails | undefined)
     }
 
     mappings.push(deliveryDetails.forename + " " + deliveryDetails.surname);
+
+    if (deliveryDetails.companyName !== "" && deliveryDetails.companyName !== undefined) {
+        mappings.push(deliveryDetails.companyName);
+    }
+
     mappings.push(deliveryDetails.addressLine1);
 
     if (deliveryDetails.addressLine2 !== "" && deliveryDetails.addressLine2 !== undefined) {

--- a/test/utils/check.details.utils.unit.test.ts
+++ b/test/utils/check.details.utils.unit.test.ts
@@ -101,7 +101,7 @@ describe("certificate.check.details.controller.unit", () => {
     describe("mapDeliveryDetails", () => {
         it("should map the correct values when all options are present", () => {
             const returnedString: string = mapDeliveryDetails(deliveryDetails);
-            const expectedString: string = "John Smith<br>" +
+            const expectedString: string = "John Smith<br>Company Name<br>" +
                 "Address Line 1<br>Address Line 2<br>Locality<br>Region<br>CF10 2AA<br>Wales<br>";
 
             chai.expect(returnedString).to.equal(expectedString);


### PR DESCRIPTION
* **This PR must be merged to master only once [BI-11726](https://github.com/companieshouse/certificates.orders.web.ch.gov.uk/pull/310) has been merged to master.**
* Note for clarity it is currently being compared with the [bi-11726-add-company-name-to-delivery-page](https://github.com/companieshouse/certificates.orders.web.ch.gov.uk/tree/bi-11726-add-company-name-to-delivery-page) branch.