### PR TITLE
CC-605: Update dependency to bring in fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.95",
+        "@companieshouse/api-sdk-node": "^2.0.103",
         "@companieshouse/node-session-handler": "^4.1.9",
         "@companieshouse/structured-logging-node": "^1.0.8",
         "cookie-parser": "~1.4.6",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.95",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.95.tgz",
-      "integrity": "sha512-oeRLJNuh8XPFocZwnDSvQaDn9UqDZYVoTPMSd6JLy68LlBBZ27wYw/RCKWDgZCD6Q9I1ghbg3Whsk9Ef9w5CNA==",
+      "version": "2.0.103",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.103.tgz",
+      "integrity": "sha512-2RZOSGXIqrZ+9d8V7b+DL8Sy2DapvqkSVLN+v31wQc93tr5TlwRstiSxO+Axz3dFgVeOwmGnbcH7x6cABAJKCw==",
       "dependencies": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.95",
+    "@companieshouse/api-sdk-node": "^2.0.103",
     "@companieshouse/node-session-handler": "^4.1.9",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "cookie-parser": "~1.4.6",


### PR DESCRIPTION
* Update the application's dependency on `api-sdk-node` to bring in [this fix](https://github.com/companieshouse/api-sdk-node/pull/593).

This PR merges "back" to `feature/ecs-service-2` as work will continue on that branch to cover later deployments to `staging` and `live`, and having this change on `feature/ecs-service-2` should at least make it possible to test the bug fix on `cidev` for now.