### PR TITLE
CC-593: Post migration cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /opt
 COPY api-enumerations ./api-enumerations
 COPY dist ./package.json ./package-lock.json docker_start.sh routes.yaml ./
 
+RUN dnf update -y && \
+        dnf install -y \
+        tar
+
 CMD ["./docker_start.sh"]
 
 EXPOSE 3000

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -18,7 +18,7 @@ custom_build(
   live_update = [
     sync(
       local_path = './dist',
-      remote_path = '/app/dist'
+      remote_path = '/opt'
     ),
     restart_container()
   ],

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -12,7 +12,7 @@ local_resource(
 )
 
 custom_build(
-  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/certificates.orders.web.ch.gov.uk:latest',
+  ref = '416670754337.dkr.ecr.eu-west-2.amazonaws.com/certificates.orders.web.ch.gov.uk:latest',
    #the following build-command was updated as specified by https://github.com/companieshouse/docker-chs-development/pull/581
    command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(ssh_key_path="$(ssh -G github.com | grep -e \'^identityfile.*\' | head -n1 | sed \'s|^identityfile \\(.*\\)|\\1|\')"; if [ -z "${ssh_key_path}" ]; then echo "Could not find ssh key path for github.com">&2; false; elif [ -f "${ssh_key_path}" ]; then cat "${ssh_key_path}"; else echo "Could not find ssh key for github at ${ssh_key_path}" >&2; false; fi)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [


### PR DESCRIPTION
### Changes

1. Make sure Tilt refers to the image held in the new `shared services` docker registry rather than the old development one.
2. Install `tar` in the local Docker container so it can be used in the local build.
3. Make the custom build sync changed files to the correct location for the Node 18 ECS migrated app that this app has now become.

### Questions regarding change 2

1. Is it necessary? Without it, see this error occurring before another rebuild is triggered, however, the build seems to succeed in getting the latest code deployed in Tilt eventually anyway:

> RUNNING: tar -C / -x -f -
> OCI runtime exec failed: exec failed: unable to start container process: exec: "tar": executable file not found in $PATH: unknown
> Build Failed: Updating container certificates-orders-web: Exec command exited with status code: 126
> This usually means that Tilt could not exec `tar`.
> Please check that the container image includes `tar` in $PATH.
> Some minimal images, such as those that are built `FROM scratch`, will not work with Live Update by default.
> See https://github.com/tilt-dev/tilt/issues/4303 for details.

2. If such a change really is necessary, might it be better to apply it once and for all in the [Node 18 base container](https://github.com/companieshouse/ci-node-build/blob/version-18/Dockerfile)?

