### PR TITLE
CC-750: Turn logging level back down to info in live

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -21,6 +21,6 @@ dispatch_days = 10
 human_log = 1
 liquidated_company_certificates_enabled = true
 tz = "Europe/London"
-log_level = "DEBUG"
+log_level = "info"
 piwik_site_id = "2"
 piwik_url = "https://matomo.companieshouse.gov.uk"


### PR DESCRIPTION
* Turn the logging level in `live` from `debug` back down to `info`, as the issue CC-750 has now been fixed in `live`.  

This reverts commit e38325e861deeec31727fdf34cfa3b60503619d4.