### PR TITLE
logic to hide summary statement content on the certificate order start page

### DIFF
--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -110,7 +110,9 @@
           {% endfor %}
         </ul>
 
+        {% if companyStatus !== "administration" and companyStatus !== "liquidation" %}
         <p class="govuk-body">The summary statement will not be added if the company does not meet the requirements, <a class="govuk-link" href="https://www.gov.uk/guidance/order-certified-copies-and-certificates-from-companies-house">see guidance on additional facts added to certificates</a>.</p>
+        {% endif %}
 
         <div class="govuk-inset-text">
           This certificate is different to the incorporation documents that were issued when the company was formed. Copies of these can be ordered through the <a href="{{ moreTabUrl }}" class='govuk-link' data-event-id="certified-copies-from-certificates">Order a certified document service</a>.

--- a/src/views/certificates/llp-certificates/index.html
+++ b/src/views/certificates/llp-certificates/index.html
@@ -109,7 +109,9 @@
           {% endfor %}
         </ul>
 
+        {% if companyStatus !== "administration" and companyStatus !== "liquidation" %}
         <p class="govuk-body">The summary statement will not be added if the company does not meet the requirements, <a class="govuk-link" href="https://www.gov.uk/guidance/order-certified-copies-and-certificates-from-companies-house">see guidance on additional facts added to certificates</a>.</p>
+        {% endif %}
 
         <div class="govuk-inset-text">
           This certificate is different to the incorporation documents that were issued when the company was formed. Copies of these can be ordered through the <a href="{{ moreTabUrl }}" class='govuk-link' data-event-id="certified-copies-from-certificates">Order a certified document service</a>.

--- a/src/views/certificates/lp-certificates/index.html
+++ b/src/views/certificates/lp-certificates/index.html
@@ -66,7 +66,9 @@
           <li>general nature of business</li>
         </ul>
 
+        {% if companyStatus !== "administration" and companyStatus !== "liquidation" %}
         <p class="govuk-body">The summary statement will not be added if the company does not meet the requirements, <a class="govuk-link" href="https://www.gov.uk/guidance/order-certified-copies-and-certificates-from-companies-house">see guidance on additional facts added to certificates</a>.</p>
+        {% endif %}
 
         <div class="govuk-inset-text">
           This certificate is different to the incorporation documents that were issued when the company was formed. Copies of these can be ordered through the <a href="{{ moreTabUrl }}" class='govuk-link' data-event-id="certified-copies-from-certificates">Order a certified document service</a>.


### PR DESCRIPTION
BI-13654: -logic to hide summary statement content on the certificate order start page