### PR TITLE
Update Certificate start page to remove "of incorporation" from certificate content

### DIFF
--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -92,7 +92,7 @@
 
         <h1 class="govuk-heading-xl">Order a certificate</h1>
 
-        <p class="govuk-body-l">Use this service to order a signed certificate of incorporation for a company, including all company name changes. </p>
+        <p class="govuk-body-l">Use this service to order a signed certificate for a company, including all company name changes. </p>
 
         <p class="govuk-body-m">You can add certain information to the certificate, including:</p>
 

--- a/test/controller/certificates/home.controller.integration.test.ts
+++ b/test/controller/certificates/home.controller.integration.test.ts
@@ -105,7 +105,7 @@ describe("certificate.home.controller.integration", () => {
             .get(replaceCompanyNumber(ROOT_CERTIFICATE, mockCompanyProfileConfiguration.companyNumber));
 
         chai.expect(resp.status).to.equal(200);
-        chai.expect(resp.text).to.contain("Use this service to order a signed certificate of incorporation for a company, including all company name changes.");
+        chai.expect(resp.text).to.contain("Use this service to order a signed certificate for a company, including all company name changes.");
         chai.expect(resp.text).to.contain("summary statement - previously known as statement of good standing");
         chai.expect(resp.text).to.contain("registered office address");
         chai.expect(resp.text).to.contain("directors");
@@ -141,7 +141,7 @@ describe("certificate.home.controller.integration", () => {
             .get(replaceCompanyNumber(ROOT_CERTIFICATE, mockCompanyProfileConfiguration.companyNumber));
 
         chai.expect(resp.status).to.equal(200);
-        chai.expect(resp.text).to.contain("Use this service to order a signed certificate of incorporation for a company, including all company name changes.");
+        chai.expect(resp.text).to.contain("Use this service to order a signed certificate for a company, including all company name changes.");
         chai.expect(resp.text).to.not.contain("summary statement previously known as statement of good standing");
         chai.expect(resp.text).to.contain("registered office address");
         chai.expect(resp.text).to.contain("directors");
@@ -201,7 +201,7 @@ describe("certificate.home.controller.integration", () => {
             .get(replaceCompanyNumber(ROOT_CERTIFICATE, mockCompanyProfileConfiguration.companyNumber));
 
         chai.expect(resp.status).to.equal(200);
-        chai.expect(resp.text).to.contain("Use this service to order a signed certificate of incorporation for a company, including all company name changes.");
+        chai.expect(resp.text).to.contain("Use this service to order a signed certificate for a company, including all company name changes.");
         chai.expect(resp.text).to.not.contain("summary statement previously known as statement of good standing");
         chai.expect(resp.text).to.contain("registered office address");
         chai.expect(resp.text).to.contain("directors");


### PR DESCRIPTION
BI-13976:Update Certificate start page to remove "of incorporation" from certificate content