### PR TITLE
add scaledown, target cpu scaling, and update modules

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -21,7 +21,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.243"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.287"
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
@@ -29,7 +29,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.243"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.287"
 
   # Environmental configuration
   environment             = var.environment

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,3 +4,8 @@ environment = "cidev"
 
 # service configs
 use_set_environment_files = true
+
+# scaling configs
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/phoenix1/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/phoenix1/vars
@@ -4,3 +4,8 @@ environment = "phoenix1"
 
 # service configs
 use_set_environment_files = true
+
+# scaling configs
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -6,3 +6,8 @@ use_set_environment_files = true
 
 # scaling configs
 desired_task_count = 2 # use multi instance in staging
+
+# scaling configs
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -67,7 +67,7 @@ variable "service_autoscale_enabled" {
 variable "service_autoscale_target_value_cpu" {
   type        = number
   description = "Target CPU percentage for the ECS Service to autoscale on"
-  default     = 50 # 100 disables autoscaling using CPU as a metric
+  default     = 80 # 100 disables autoscaling using CPU as a metric
 }
 variable "service_scaledown_schedule" {
   type        = string


### PR DESCRIPTION
Update modules to latest version, configure target cpu for scaling to 80% instead of 50%. Also added scale down and up. CPU and memory metrics look ok in aws for the different environments.