### PR TITLE
BI-13999-add changes for standard delivery option to direct to additional copies

### DIFF
--- a/src/controllers/certificates/additional.copies.controller.ts
+++ b/src/controllers/certificates/additional.copies.controller.ts
@@ -23,7 +23,8 @@ export const render = async (req: Request, res: Response, next: NextFunction): P
         logger.info(`Render additional copies options page`);
         const accessToken: string = getAccessToken(req.session);
         const certificateItem: CertificateItem = await getCertificateItem(accessToken, req.params.certificateId);
-        const backLink = EMAIL_OPTIONS;
+        const backLink = setBackLink(certificateItem, req.session)
+
 
         await renderPage(req, res, ADDITIONAL_COPIES, PAGE_TITLE, certificateItem, backLink);
     } catch (err) {

--- a/src/controllers/certificates/delivery.options.controller.ts
+++ b/src/controllers/certificates/delivery.options.controller.ts
@@ -3,7 +3,7 @@ import { check, validationResult } from "express-validator";
 import { CertificateItem, CertificateItemPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { getAccessToken, getUserId } from "../../session/helper";
 import { appendItemToBasket, getBasket, getCertificateItem, patchCertificateItem } from "../../client/api.client";
-import { DELIVERY_DETAILS, DELIVERY_OPTIONS, EMAIL_OPTIONS } from "../../model/template.paths";
+import { ADDITIONAL_COPIES, DELIVERY_DETAILS, DELIVERY_OPTIONS, EMAIL_OPTIONS } from "../../model/template.paths";
 import { createLogger } from "@companieshouse/structured-logging-node";
 import { APPLICATION_NAME, DISPATCH_DAYS } from "../../config/config";
 import { setServiceUrl } from "../../utils/service.url.utils";
@@ -24,7 +24,6 @@ const validators = [
     check("deliveryOptions").not().isEmpty().withMessage(DELIVERY_OPTION_SELECTION)
 ];
 
-const redirectCallback = new StaticRedirectCallback(BY_ITEM_KIND);
 
 export const render = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -100,14 +99,11 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             logger.info(`Patched certificate item with delivery option, id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);
             const basket = await getBasket(accessToken);
             if (certificateItemPatchRequest.itemOptions?.deliveryTimescale === "same-day") {
+                logger.info("same day if satateent to email options")
                 return res.redirect(EMAIL_OPTIONS);
             } else if (basket.enrolled) {
                 await appendItemToBasket(accessToken, { itemUri: certificateItem.links.self });
-                return redirectCallback.redirectEnrolled({
-                    response: res,
-                    items: basket.items,
-                    deliveryDetails: basket.deliveryDetails
-                });
+                return res.redirect(ADDITIONAL_COPIES);
             } else {
                 return res.redirect(DELIVERY_DETAILS);
             }

--- a/src/controllers/certificates/delivery.options.controller.ts
+++ b/src/controllers/certificates/delivery.options.controller.ts
@@ -99,7 +99,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             logger.info(`Patched certificate item with delivery option, id=${req.params.certificateId}, user_id=${userId}, company_number=${certificatePatchResponse.companyNumber}`);
             const basket = await getBasket(accessToken);
             if (certificateItemPatchRequest.itemOptions?.deliveryTimescale === "same-day") {
-                logger.info("same day if satateent to email options")
                 return res.redirect(EMAIL_OPTIONS);
             } else if (basket.enrolled) {
                 await appendItemToBasket(accessToken, { itemUri: certificateItem.links.self });

--- a/test/controller/certificates/delivery.options.controller.integration.test.ts
+++ b/test/controller/certificates/delivery.options.controller.integration.test.ts
@@ -153,7 +153,7 @@ describe("delivery.options.integration.test", () => {
             chai.expect(resp.text).to.include("Found. Redirecting to email-options");
         });
 
-        it("adds item to basket and redirects user to the basket page if enrolled", async () => {
+        it("redirects the user to the additional-copies page", async () => {
             const certificateDetails = {
                 itemOptions: {
                     deliveryTimescale: "standard"
@@ -183,10 +183,10 @@ describe("delivery.options.integration.test", () => {
                 });
 
             chai.expect(resp.status).to.equal(302);
-            chai.expect(resp.text).to.include("Found. Redirecting to /basket");
+            chai.expect(resp.text).to.include("Found. Redirecting to additional-copies");
         });
 
-        it("enrolled user redirected to delivery details page if no other deliverable items", async () => {
+        it("enrolled user redirected to additional copies page if no other deliverable items", async () => {
             const certificateDetails = {
                 itemOptions: {
                     deliveryTimescale: "standard"
@@ -216,7 +216,7 @@ describe("delivery.options.integration.test", () => {
                 });
 
             chai.expect(resp.status).to.equal(302);
-            chai.expect(resp.text).to.include("Found. Redirecting to /delivery-details");
+            chai.expect(resp.text).to.include("Found. Redirecting to additional-copies");
         });
     });
 


### PR DESCRIPTION
Resolves [BI-13999](https://companieshouse.atlassian.net/browse/BI-13999) 

- Add changes for standard delivery option page to direct to additional copies
- Ensure back link redirects to correct page depending on delivery option choses (e.g no email option for standard_) 
- Edit tests to support new journey flow. 

[BI-13999]: https://companieshouse.atlassian.net/browse/BI-13999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ