### PR TITLE
GCI-2582- Resolve incorrect quantity set for additional-copies

### DIFF
--- a/src/controllers/certificates/additional.copies.quantity.controller.ts
+++ b/src/controllers/certificates/additional.copies.quantity.controller.ts
@@ -54,14 +54,15 @@ export const route = async (req: Request, res: Response, next: NextFunction): Pr
                 errorList: [additionalCopiesQuantityErrorData]
             });
         } else {
-            logger.info(`User has selected quantity=${additionalCopiesQuantity} of additional copies`);
+            const currentQuantity= certificateItem.quantity
+            logger.info(`User has selected ${additionalCopiesQuantity} additional copies`);
             const certificateItemPatchRequest: CertificateItemPatchRequest = {
-                quantity : parseInt(additionalCopiesQuantity)
+                quantity : currentQuantity + parseInt(additionalCopiesQuantity)
             };
-
+            
             const patchedCertificateItem = await patchCertificateItem(accessToken, req.params.certificateId, certificateItemPatchRequest);
             logger.info(`Patched certificate item with delivery option, id=${req.params.certificateId}, user_id=${userId}, company_number=${patchedCertificateItem.companyNumber}`);
-
+            logger.info(`Quantity has been updated to: ${patchedCertificateItem.quantity} ` );
             const basket = await getBasket(accessToken);
             if (basket.enrolled) {
                 await appendItemToBasket(accessToken,{ itemUri: patchedCertificateItem.links.self});


### PR DESCRIPTION

Resolves [GCI-2582] (https://companieshouse.atlassian.net/browse/GCI-2582)

Update patch so that the additional copies number chosen by is appended to initial quantity to avoid incorrect quantity calculation.
e.g  Initial quantity is always 1 so if user chooses 3 copies , then total quantity should be 4. 


<img width="1296" alt="Screenshot 2024-09-11 at 09 05 55" src="https://github.com/user-attachments/assets/3f4877fd-cbc9-477d-8c4f-70b7422520cb">
<img width="1296" alt="Screenshot 2024-09-11 at 09 06 05" src="https://github.com/user-attachments/assets/e87089ff-804e-4a03-ac2f-d398a71d3a7d">


[GCI-2582]: https://companieshouse.atlassian.net/browse/GCI-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ