### PR TITLE
BI-12033 Add quantity to LLP,LP and dissolved check certificate pages

### DIFF
--- a/src/controllers/certificates/check-details/LLPCheckDetailsFactory.ts
+++ b/src/controllers/certificates/check-details/LLPCheckDetailsFactory.ts
@@ -47,6 +47,7 @@ export class LLPCheckDetailsFactory implements ViewModelCreatable {
             registeredOfficeAddress: this.textMapper.mapAddressOption(itemOptions.registeredOfficeAddressDetails?.includeAddressRecordsType),
             liquidatorsDetails: this.textMapper.isOptionSelected(itemOptions.liquidatorsDetails?.includeBasicInformation),
             administratorsDetails: this.textMapper.isOptionSelected(itemOptions.administratorsDetails?.includeBasicInformation),
+            quantity: certificateItem.quantity,
             filterMappings: {
                 statementOfGoodStanding: certificateItem.itemOptions.companyStatus === CompanyStatus.ACTIVE,
                 liquidators: certificateItem.itemOptions.companyStatus === CompanyStatus.LIQUIDATION,

--- a/src/controllers/certificates/check-details/LPCompanyCheckDetailsFactory.ts
+++ b/src/controllers/certificates/check-details/LPCompanyCheckDetailsFactory.ts
@@ -44,7 +44,8 @@ export class LPCheckDetailsFactory implements ViewModelCreatable {
             principalPlaceOfBusiness: this.textMapper.mapAddressOption(itemOptions.principalPlaceOfBusinessDetails?.includeAddressRecordsType),
             generalPartners: this.textMapper.isOptionSelected(itemOptions.generalPartnerDetails?.includeBasicInformation),
             limitedPartners: this.textMapper.isOptionSelected(itemOptions.limitedPartnerDetails?.includeBasicInformation),
-            generalNatureOfBusiness: this.textMapper.isOptionSelected(itemOptions.includeGeneralNatureOfBusinessInformation)
+            generalNatureOfBusiness: this.textMapper.isOptionSelected(itemOptions.includeGeneralNatureOfBusinessInformation),
+            quantity: certificateItem.quantity,
         };
     };
 

--- a/src/views/certificates/check-details-alternate.html
+++ b/src/views/certificates/check-details-alternate.html
@@ -340,6 +340,22 @@
                       }
                     ]
                   }
+                },
+                {
+                  id: "quantity",
+                  key: {
+                    text: "Quantity"
+                  },
+                  value: {
+                    text: quantity
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "quantity"
+                      }
+                    ]
+                  }
                 }
               ]
             }) }}

--- a/src/views/certificates/llp-certificates/check-details-alternate.html
+++ b/src/views/certificates/llp-certificates/check-details-alternate.html
@@ -206,6 +206,22 @@
                       }
                     ]
                   }
+                },
+                {
+                  id: "quantity",
+                  key: {
+                    text: "Quantity"
+                  },
+                  value: {
+                    text: quantity
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "quantity"
+                      }
+                    ]
+                  }
                 }
               ], filterMappings)
             }) }}
@@ -289,6 +305,22 @@
                     items: [
                       {
                         visuallyHiddenText: "email copy required"
+                      }
+                    ]
+                  }
+                },
+                {
+                  id: "quantity",
+                  key: {
+                    text: "Quantity"
+                  },
+                  value: {
+                    text: quantity
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "quantity"
                       }
                     ]
                   }

--- a/src/views/certificates/lp-certificates/check-details-alternate.html
+++ b/src/views/certificates/lp-certificates/check-details-alternate.html
@@ -181,6 +181,22 @@
                       }
                     ]
                   }
+                },
+                {
+                  id: "quantity",
+                  key: {
+                    text: "Quantity"
+                  },
+                  value: {
+                    text: quantity
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "quantity"
+                      }
+                    ]
+                  }
                 }
               ]
             }) }}
@@ -264,6 +280,22 @@
                     items: [
                       {
                         visuallyHiddenText: "email copy required"
+                      }
+                    ]
+                  }
+                },
+                {
+                  id: "quantity",
+                  key: {
+                    text: "Quantity"
+                  },
+                  value: {
+                    text: quantity
+                  },
+                  actions: {
+                    items: [
+                      {
+                      visuallyHiddenText: "quantity"
                       }
                     ]
                   }

--- a/test/controller/certificates/check-details/LLPCompanyCheckDetailsFactory.unit.test.ts
+++ b/test/controller/certificates/check-details/LLPCompanyCheckDetailsFactory.unit.test.ts
@@ -19,6 +19,7 @@ const CERTIFICATE_MODEL: CertificateItem = {
     id: "F00DFACE",
     companyName: "ACME LTD",
     companyNumber: "12345678",
+    quantity: 1,
     itemCosts: [{
         itemCost: "10"
     }],
@@ -47,6 +48,7 @@ const EXPECTED_RESULT = {
     registeredOfficeAddress: MAPPED_ADDRESS_OPTION,
     liquidatorsDetails: MAPPED_OPTION_VALUE,
     administratorsDetails: MAPPED_OPTION_VALUE,
+    quantity: 1,
     filterMappings: {
         statementOfGoodStanding: true,
         liquidators: false,

--- a/test/controller/certificates/check-details/LPCompanyCheckDetailsFactory.unit.test.ts
+++ b/test/controller/certificates/check-details/LPCompanyCheckDetailsFactory.unit.test.ts
@@ -21,6 +21,7 @@ const CERTIFICATE_MODEL: CertificateItem = {
     id: "F00DFACE",
     companyName: "ACME LTD",
     companyNumber: "12345678",
+    quantity: 1,
     itemCosts: [{
         itemCost: "10"
     }],
@@ -46,7 +47,8 @@ const EXPECTED_RESULT = {
     principalPlaceOfBusiness: MAPPED_ADDRESS_OPTION,
     generalPartners: MAPPED_OPTION_VALUE,
     limitedPartners: MAPPED_OPTION_VALUE,
-    generalNatureOfBusiness: MAPPED_OPTION_VALUE
+    generalNatureOfBusiness: MAPPED_OPTION_VALUE,
+    quantity: 1,
 };
 
 describe("LPCheckDetailsFactory", () => {


### PR DESCRIPTION
Resolves [BI-12033](https://companieshouse.atlassian.net/browse/BI-12033)


Following Wayne's observations in test (see ticket) -adding missing quantity field to check certificate pages for LL, LLP and dissolved companies


[BI-12033]: https://companieshouse.atlassian.net/browse/BI-12033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ