### PR TITLE
Bug/GCI-2588 fix direct to incorrect page for standard delivery option

### DIFF
--- a/src/controllers/certificates/delivery.options.controller.ts
+++ b/src/controllers/certificates/delivery.options.controller.ts
@@ -101,7 +101,6 @@ const route = async (req: Request, res: Response, next: NextFunction) => {
             if (certificateItemPatchRequest.itemOptions?.deliveryTimescale === "same-day") {
                 return res.redirect(EMAIL_OPTIONS);
             } else if (basket.enrolled) {
-                await appendItemToBasket(accessToken, { itemUri: certificateItem.links.self });
                 return res.redirect(ADDITIONAL_COPIES);
             } else {
                 return res.redirect(DELIVERY_DETAILS);

--- a/test/controller/certificates/delivery.options.controller.integration.test.ts
+++ b/test/controller/certificates/delivery.options.controller.integration.test.ts
@@ -170,9 +170,7 @@ describe("delivery.options.integration.test", () => {
                 .returns(Promise.resolve(certificateDetails));
             getBasketStub = sandbox.stub(apiClient, "getBasket")
                 .returns(Promise.resolve({ enrolled: true, items: [{ kind: "item#certificate" } as any], deliveryDetails }));
-            sandbox.mock(apiClient).expects("appendItemToBasket")
-                .once()
-                .returns(Promise.resolve());
+     
 
             const resp = await chai.request(testApp)
                 .post(DELIVERY_OPTIONS_URL)
@@ -203,9 +201,6 @@ describe("delivery.options.integration.test", () => {
                 .returns(Promise.resolve(certificateDetails));
             getBasketStub = sandbox.stub(apiClient, "getBasket")
                 .returns(Promise.resolve({ enrolled: true, items: [{ kind: "item#missing-image-delivery" } as any] }));
-            sandbox.mock(apiClient).expects("appendItemToBasket")
-                .once()
-                .returns(Promise.resolve());
 
             const resp = await chai.request(testApp)
                 .post(DELIVERY_OPTIONS_URL)


### PR DESCRIPTION
Resolves [GCI-2588](https://companieshouse.atlassian.net/browse/GCI-2588) 
Fix to allow selecting standard service to match behaviour of express service as a delivery option. 
User should be directed to the delivery details page after selecting  additional copies and selecting the amount of copies (if they haven't used service before) and item should be added to basket only once user has reached delivery details page in al scenarios, not on delivery option page.

[GCI-2588]: https://companieshouse.atlassian.net/browse/GCI-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ