### PR TITLE
GCI-2580- prevent incorrect quantity when using the browser back button

### DIFF
--- a/src/controllers/certificates/additional.copies.controller.ts
+++ b/src/controllers/certificates/additional.copies.controller.ts
@@ -69,7 +69,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
                     const certificateItemPatchRequest: CertificateItemPatchRequest = {
                         quantity : baseQuantity
                 };
-                const certificateItem = await patchCertificateItem(accessToken, req.params.certificateId, certificateItemPatchRequest);
+                certificateItem = await patchCertificateItem(accessToken, req.params.certificateId, certificateItemPatchRequest);
                 logger.info(`Total quantity has been reset back to: ${certificateItem.quantity} ` );
             }
                 const basket = await getBasket(accessToken);

--- a/src/controllers/certificates/additional.copies.controller.ts
+++ b/src/controllers/certificates/additional.copies.controller.ts
@@ -43,7 +43,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
         const userId = getUserId(req.session);
         const accessToken: string = getAccessToken(req.session);
         const additionalCopies: string = req.body[ADDITIONAL_COPIES_OPTION_FIELD];
-        const certificateItem: CertificateItem = await getCertificateItem(accessToken, req.params.certificateId);
+        let certificateItem: CertificateItem = await getCertificateItem(accessToken, req.params.certificateId);
         logger.info(`Get certificate item, id=${certificateItem.id}, user_id=${userId}, company_number=${certificateItem.companyNumber}`);
         
         if (!errors.isEmpty()) {

--- a/src/controllers/certificates/additional.copies.quantity.controller.ts
+++ b/src/controllers/certificates/additional.copies.quantity.controller.ts
@@ -54,10 +54,10 @@ export const route = async (req: Request, res: Response, next: NextFunction): Pr
                 errorList: [additionalCopiesQuantityErrorData]
             });
         } else {
-            const currentQuantity= certificateItem.quantity
+            const baseQuantity = 1;
             logger.info(`User has selected ${additionalCopiesQuantity} additional copies`);
             const certificateItemPatchRequest: CertificateItemPatchRequest = {
-                quantity : currentQuantity + parseInt(additionalCopiesQuantity)
+                quantity : baseQuantity + parseInt(additionalCopiesQuantity)
             };
             
             const patchedCertificateItem = await patchCertificateItem(accessToken, req.params.certificateId, certificateItemPatchRequest);


### PR DESCRIPTION
Resolves [GCI-2589](https://companieshouse.atlassian.net/browse/GCI-2589)

Change Additional Quantity Controller to set a base quantity each time the user navigates back to the this page via the browser's back button.
Also change Additional Quantity option page (yes or no) so that if the user has picked additional quantities before and navigate back via back button and they pick 'no' the quantity will reset to 1. 
This should ensure that the amount of additional copies/certificates is not added on to the quantity total previously chosen and is now patched correctly with the new quantity. 
[GCI-2589]: https://companieshouse.atlassian.net/browse/GCI-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ