### PR TITLE
GCI-2593:fix conflict between warning and error messages showing at the same time and also fix register link going to live link

### DIFF
--- a/src/views/certificates/index.html
+++ b/src/views/certificates/index.html
@@ -13,38 +13,36 @@
 
 {% block content %}
 
-    {% if basketLimitState == "display-limit-error" %}
-        {{ govukErrorSummary({
-          titleText: ERROR_SUMMARY_TITLE,
-          errorList: [
-            {
-              text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
-              href: basketWebUrl
-            }
-          ]
-        }) }}
-    {% endif %}
+  {% if basketLimitState == "display-limit-error" %}
+  {{ govukErrorSummary({
+  titleText: ERROR_SUMMARY_TITLE,
+  errorList: [
+  {
+  text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
+  href: basketWebUrl
+  }
+  ]
+  }) }}
+  {% elseif basketLimitState != "below-limit" %}
+  <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title">
+        Important
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
+      <p class="govuk-body">
+        You cannot add more than {{ basketLimit }} items to your order.
+        To add more, you'll need to remove some items first.
+      </p>
+    </div>
+  </div>
+  {% endif %}
 
   {% if companyStatus === "dissolved" %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        {% if basketLimitState != "below-limit" %}
-          <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title">
-                Important
-              </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-              <p class="govuk-body">
-                You cannot add more than {{ basketLimit }} items to your order.
-                To add more, you'll need to remove some items first.
-              </p>
-            </div>
-          </div>
-         {% endif %}
 
         <p class="govuk-caption-l">{{ companyName }}</p>
 
@@ -58,8 +56,9 @@
 
         {% if basketLimitState == "below-limit" %}
           <p class="govuk-body">To order for a different company,
-            <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
-         {% endif %}
+            <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+          </p>
+        {% endif %}
 
         {{ govukButton({
           text: "Start now",
@@ -106,23 +105,6 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-      {% if basketLimitState != "below-limit" %}
-        <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-          <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title">
-              Important
-            </h2>
-          </div>
-          <div class="govuk-notification-banner__content">
-            <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-            <p class="govuk-body">
-              You cannot add more than {{ basketLimit }} items to your order.
-              To add more, you'll need to remove some items first.
-            </p>
-          </div>
-        </div>
-      {% endif %}
-
         <p class="govuk-caption-l">{{ companyName }}</p>
 
         <h1 class="govuk-heading-xl">Order a company certificate</h1>
@@ -168,7 +150,8 @@
 
 
         <p class="govuk-body">To order for a different company,
-          <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
+          <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+        </p>
 
 
         {{ govukButton({

--- a/src/views/certificates/llp-certificates/index.html
+++ b/src/views/certificates/llp-certificates/index.html
@@ -13,42 +13,38 @@
 
 {% block content %}
 
-    {% if basketLimitState == "display-limit-error" %}
-        {{ govukErrorSummary({
-          titleText: ERROR_SUMMARY_TITLE,
-          errorList: [
-            {
-              text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
-              href: basketWebUrl
-            }
-          ]
-        }) }}
-    {% endif %}
+  {% if basketLimitState == "display-limit-error" %}
+  {{ govukErrorSummary({
+  titleText: ERROR_SUMMARY_TITLE,
+  errorList: [
+  {
+  text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
+  href: basketWebUrl
+  }
+  ]
+  }) }}
+  {% elseif basketLimitState != "below-limit" %}
+  <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title">
+        Important
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
+      <p class="govuk-body">
+        You cannot add more than {{ basketLimit }} items to your order.
+        To add more, you'll need to remove some items first.
+      </p>
+    </div>
+  </div>
+  {% endif %}
 
   {% if companyStatus === "dissolved" %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        {% if basketLimitState != "below-limit" %}
-          <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title">
-                Important
-              </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-              <p class="govuk-body">
-                You cannot add more than {{ basketLimit }} items to your order.
-                To add more, you'll need to remove some items first.
-              </p>
-            </div>
-          </div>
-        {% endif %}
-
-          <p class="govuk-caption-l">{{ companyName }}</p>
+        <p class="govuk-caption-l">{{ companyName }}</p>
           <h1 class="govuk-heading-xl">Order a company certificate</h1>
-
         <p class="govuk-body-l">Use this service to order a signed certificate of dissolution for a company, including all company name changes. </p>
 
         <p class="govuk-body">You can order additional copies of a certificate if you need to.</p>
@@ -56,8 +52,8 @@
         <p class="govuk-body">Ordering a certificate takes around 5 minutes.</p>
 
         <p class="govuk-body">To order for a different company,
-          <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
-
+          <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+        </p>
 
         {{ govukButton({
             text: "Start now",
@@ -103,24 +99,6 @@
   {% else %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        {% if basketLimitState != "below-limit" %}
-          <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-              <div class="govuk-notification-banner__header">
-                  <h2 class="govuk-notification-banner__title">
-                      Important
-                  </h2>
-              </div>
-              <div class="govuk-notification-banner__content">
-                  <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-                  <p class="govuk-body">
-                      You cannot add more than {{ basketLimit }} items to your order.
-                      To add more, you'll need to remove some items first.
-                  </p>
-              </div>
-          </div>
-        {% endif %}
-
         <p class="govuk-caption-l">{{ companyName }}</p>
 
         <h1 class="govuk-heading-xl">Order a company certificate</h1>
@@ -164,7 +142,8 @@
         </ul>
 
           <p class="govuk-body">To order for a different company,
-            <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
+            <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+          </p>
 
         {{ govukButton({
             text: "Start now",

--- a/src/views/certificates/lp-certificates/index.html
+++ b/src/views/certificates/lp-certificates/index.html
@@ -12,39 +12,36 @@
 {% endblock %}
 
 {% block content %}
-
-    {% if basketLimitState == "display-limit-error" %}
-      {{ govukErrorSummary({
-        titleText: ERROR_SUMMARY_TITLE,
-        errorList: [
-          {
-            text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
-            href: basketWebUrl
-          }
-        ]
-      }) }}
-    {% endif %}
+  {% if basketLimitState == "display-limit-error" %}
+  {{ govukErrorSummary({
+  titleText: ERROR_SUMMARY_TITLE,
+  errorList: [
+  {
+  text: "Your basket is full. To add more to your order, you'll need to remove some items first.",
+  href: basketWebUrl
+  }
+  ]
+  }) }}
+  {% elseif basketLimitState != "below-limit" %}
+  <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title">
+        Important
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
+      <p class="govuk-body">
+        You cannot add more than {{ basketLimit }} items to your order.
+        To add more, you'll need to remove some items first.
+      </p>
+    </div>
+  </div>
+  {% endif %}
 
   {% if companyStatus === "active" %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        {% if basketLimitState != "below-limit" %}
-          <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title">
-                Important
-              </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-              <p class="govuk-body">
-                You cannot add more than {{ basketLimit }} items to your order.
-                To add more, you'll need to remove some items first.
-              </p>
-            </div>
-          </div>
-        {% endif %}
 
         <p class="govuk-caption-l">{{ companyName }}</p>
         <h1 class="govuk-heading-xl">Order a company certificate</h1>
@@ -83,7 +80,8 @@
         </ul>
 
         <p class="govuk-body">To order for a different company,
-          <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
+          <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+        </p>
 
         {{ govukButton({
           text: "Start now",
@@ -140,25 +138,11 @@
 
         <p class="govuk-body">Ordering a certificate takes around 5 minutes.</p>
 
-        {% if basketLimitState != "below-limit" %}
+        {% if basketLimitState == "below-limit" %}
           <p class="govuk-body">To order for a different company,
-            <a class="govuk-notification-banner__link" href="https://find-and-update.company-information.service.gov.uk/">search for the company on the register</a>.</p>
-          {% else %}
-          <div class="govuk-notification-banner" role="region" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Important
-              </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">Your basket is full</h3>
-              <p class="govuk-body">
-                You cannot add more than {{ basketLimit }} items to your order.
-                To add more, you'll need to remove some items first.
-              </p>
-            </div>
-          </div>
-         {% endif %}
+            <a class="govuk-notification-banner__link" href="/">search for the company on the register</a>.
+          </p>
+        {% endif %}
 
         {{ govukButton({
           text: "Start now",


### PR DESCRIPTION
Resolves: [GCI-2593](https://companieshouse.atlassian.net/browse/GCI-2593) and [GCI-2594](https://companieshouse.atlassian.net/browse/GCI-2594)

<img width="1241" alt="Screenshot 2024-10-17 at 10 26 09" src="https://github.com/user-attachments/assets/f5062a6e-19bd-4b22-83e2-d12e840f12ae">
<img width="1235" alt="Screenshot 2024-10-17 at 10 26 39" src="https://github.com/user-attachments/assets/b47e7757-1740-4134-a861-19745de81eff">


[GCI-2593]: https://companieshouse.atlassian.net/browse/GCI-2593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GCI-2594]: https://companieshouse.atlassian.net/browse/GCI-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ