### PR TITLE
CC-593: fix gulp encoding for fonts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const sass = gulpSass(dartSass);
 gulp.task("govuk-frontend-copy", function() {
   return gulp.src([
     "./node_modules/govuk-frontend/govuk/assets/**/*"
-  ]).pipe(gulp.dest("./dist/static"));
+  ], {encoding: false}).pipe(gulp.dest("./dist/static"));
 });
 // compiles the sass down to css
 gulp.task('sass', function() {


### PR DESCRIPTION
due to how Gulp 5.0.0 works, this now resolves the encoding issue with static assets. 